### PR TITLE
[ADD] Adding tolerations and nodeSelector depending on the service ty…

### DIFF
--- a/charts/adhoc-odoo/v0.1.0/templates/deployment.yaml
+++ b/charts/adhoc-odoo/v0.1.0/templates/deployment.yaml
@@ -252,6 +252,7 @@ spec:
             # {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.isProd }}
       affinity:
           # Don't co-locate pods of this service with any other pods including pods of this service
           # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/podaffinity.md
@@ -269,11 +270,14 @@ spec:
                   operator: In
                   values:
                   - "true"
-
+      {{- end }}
+      {{ if .Values.isProd }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/adhoc-odoo/v0.1.0/values.yaml
+++ b/charts/adhoc-odoo/v0.1.0/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+isProd: false
+
 image:
   repository: adhoc/odoo-adhoc
   pullPolicy: IfNotPresent
@@ -85,8 +87,15 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 90
 
-nodeSelector: {}
-tolerations: {}
+# Prod
+nodeSelector:
+  cloud.google.com/gke-spot: 'true'
+
+tolerations:
+  - key: cloud.google.com/gke-spot
+    operator: Equal
+    value: "true"
+    effect: PreferNoSchedule
 
 multiEnvVariables:
   # example: "yes"


### PR DESCRIPTION
Adding tolerations and NodeSelector based on the deployment type, it could be prod or test (train too).
We want to ensure test/train deployment only on Spot instances.
For cost efficiency, we would like to deploy new prod HPAs replicas on spot pool.