### PR TITLE
enable nodeTag (prod as default)

### DIFF
--- a/charts/adhoc-odoo/v0.1.1/questions.yml
+++ b/charts/adhoc-odoo/v0.1.1/questions.yml
@@ -134,6 +134,12 @@ questions:
     type: "string"
     required: false
     default: ""
+  - variable: odoo.saas.nodeTag
+    label: "Odoo NODE_TAG"
+    description: "Odoo NODE_TAG var (prod, train, test, demo, new, bu)"
+    type: "string"
+    required: false
+    default: "prod"
 # Performance Configuration
   - variable: odoo.performance.workers
     group: performance

--- a/charts/adhoc-odoo/v0.1.1/values.yaml
+++ b/charts/adhoc-odoo/v0.1.1/values.yaml
@@ -153,4 +153,4 @@ storage:
   aws_access_key_id: "keyId"
   aws_secret_access_key: "secret"
 
-nodeTag: "prod"
+nodeTag: ""


### PR DESCRIPTION
Actualmente el chart aplica por defecto nodeTag = prod. La intención es pasarle ese valor para que eventualmente podamos alocar bases / pods en nodos definidos para cada caso, eventualmente nodos spot, etc.
Básicamente para no pasar "prod" por defecto e incorporarlo al catálogo.
Gracias!