### PR TITLE
fix: bump odooEdgeProxy tag → 2026.05.21.1 (CVE-2026-42945)

### DIFF
--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -169,7 +169,7 @@ ingress:
     image:
       # repository: nginx
       repository: dockerhub.adhoc.inc/adhoc/ops-tools
-      tag: "odooEdgeProxy-2026.05.06.9"
+      tag: "odooEdgeProxy-2026.05.21.1"
     loadBalancerCIDR: 10.0.0.0/8
     internalClusterCIDR: 10.0.0.0/8
     # Monitoring


### PR DESCRIPTION
## Cambio

`charts/adhoc-odoo/values.yaml` — tag de odooEdgeProxy:

```
odooEdgeProxy-2026.05.06.9  →  odooEdgeProxy-2026.05.21.1
```

## Motivo

CVE-2026-42945 — RCE no autenticado en `ngx_http_rewrite_module` de NGINX. La imagen anterior incluía NGINX 1.29.8 (vulnerable). La nueva incluye NGINX 1.31.0 (parcheado) y elimina el paquete `curl` que tenía 2 CVEs High.

Fix de imagen: ingadhoc/devops-ops-tools#4

## Validación

Imagen `odooEdgeProxy-2026.05.21.1` testeada en grittiagrimensura (adhocprod): nginx/1.31.0 confirmado, proxy operativo, WAF funcional.

## Rollout

Al mergear este PR, el chart default apunta a la nueva imagen. El rollout efectivo en cada namespace depende de cuándo se ejecute el `helm upgrade` correspondiente.