### PR TITLE
chore: ampliar lista de bots bloqueados en nginx

### DIFF
--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -146,18 +146,50 @@ ingress:
     botBlock:
       enabled: true
       blockedUserAgents:
+        # AI / LLM training crawlers
         - GPTBot
         - ChatGPT-User
+        - OAI-SearchBot
         - CCBot
         - anthropic-ai
+        - ClaudeBot
         - Claude
+        - Google-Extended
+        - PerplexityBot
+        - Applebot-Extended
+        - Meta-ExternalAgent
+        - FacebookBot
+        - cohere-ai
+        - Diffbot
+        - YouBot
+        - Amazonbot
+        - Timpibot
+        - img2dataset
+        # AI search / otros LLMs
         - Bytespider
-        - Barkrowler
-        - SemrushBot
-        - Thinkbot
-        - bingbot
         - PetalBot
+        - Thinkbot
+        # SEO crawlers agresivos
+        - AhrefsBot
+        - SemrushBot
+        - DotBot
+        - MJ12bot
+        - BLEXBot
+        - DataForSeoBot
+        - serpstatbot
+        - SEOkicks
+        - rogerbot
+        - Barkrowler
+        # Motores con comportamiento agresivo o bloqueados por política
+        - bingbot
+        - msnbot
+        - adidxbot
         - Baiduspider
+        - YandexBot
+        - Exabot
+        # Scrapers / otros
+        - MegaIndex
+        - linkdexbot
     rateLimit:
       enabled: false
       static: 1000r/m


### PR DESCRIPTION
## Cambios

Amplía la lista `blockedUserAgents` en `values.yaml` con bots conocidos por uso abusivo o scraping masivo.

**AI/LLM training crawlers agregados:** `OAI-SearchBot`, `ClaudeBot`, `Google-Extended`, `PerplexityBot`, `Applebot-Extended`, `Meta-ExternalAgent`, `FacebookBot`, `cohere-ai`, `Diffbot`, `YouBot`, `Amazonbot`, `Timpibot`, `img2dataset`

**SEO crawlers agresivos:** `AhrefsBot`, `DotBot`, `MJ12bot`, `BLEXBot`, `DataForSeoBot`, `serpstatbot`, `SEOkicks`, `rogerbot`

**Motores con comportamiento agresivo:** `msnbot`, `adidxbot`, `YandexBot`, `Exabot`

**Scrapers varios:** `MegaIndex`, `linkdexbot`

También se agregaron comentarios de sección para facilitar el mantenimiento futuro.

## Referencias

- Lista curada de AI crawlers: https://github.com/ai-robots-txt/ai.robots.txt