### PR TITLE
feat: agregar chart adhoc-wakeup-controller y soporte wakeupController en adhoc-odoo

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -185,3 +185,16 @@ Restoring the database we need to scale down to 0, so if replicaCount is set to 
     (ne (.Values.replicaCount | int) 0)
 -}}
 {{- end -}}
+
+{{/*
+wakeupController.enabled — true when KEDA + wakeup controller are both active
+and minReplicas is 0 (scale-to-zero mode).
+*/}}
+{{- define "wakeupController.enabled" -}}
+{{- and
+    (eq (include "keda.enabled" . | trim) "true")
+    (.Values.autoscaling.wakeupController.enabled | default false)
+    (eq (.Values.autoscaling.minReplicas | int) 0)
+    (ne (.Values.autoscaling.wakeupController.controllerSvc | default "") "")
+-}}
+{{- end -}}

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -3,6 +3,9 @@
 {{- $odooImage := include "odoo.image" . -}}
 {{ $replicaCount := (default 1 .Values.replicaCount) | int }}
 {{- $isKedaEnabled := eq (include "keda.enabled" . | trim) "true" -}}
+{{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
+{{- $fullName := include "adhoc-odoo.serviceNameSuffix" . -}}
+{{- $svcHost := ternary (printf "%s-nginx" $fullName) (printf "%s-http" $fullName) .Values.ingress.reverseProxy.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,6 +17,16 @@ metadata:
     "kubernetes.io/change-cause": {{ .Values.changeCause | quote }}
     "adhoc.ar/dev-name": "" # Used to identify the developer that deployed the app
     "adhoc.ar/dev-r2cmd": "" # Used to store the r2cmd command to redeploy the app
+    {{- if $isWakeupEnabled }}
+    "wakeup.adhoc.inc/managed": "true"
+    "wakeup.adhoc.inc/state": "ready"
+    "wakeup.adhoc.inc/vs-shared": {{ printf "%s-shared" .Values.odoo.pg.db | quote }}
+    "wakeup.adhoc.inc/vs-custom": {{ ternary (printf "%s-custom" .Values.odoo.pg.db) "" (ne .Values.ingress.istio.altHosts "") | quote }}
+    "wakeup.adhoc.inc/svc-host": {{ $svcHost | quote }}
+    "wakeup.adhoc.inc/svc-port": "80"
+    "wakeup.adhoc.inc/ws-host": {{ ternary (printf "%s-websocket" $fullName) "" (gt (.Values.odoo.performance.workers | toString | int) 0) | quote }}
+    "wakeup.adhoc.inc/instance": {{ .Values.odoo.pg.db | quote }}
+    {{- end }}
 spec:
   {{- if not (or .Values.autoscaling.hpa.enabled $isKedaEnabled) }}
   replicas: {{ .Values.replicaCount | int }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
@@ -9,12 +9,13 @@
 {{- $srvWs := printf "%s-websocket" $fullName }}
 {{- $srvPort := 80 }}
 {{- $isKedaEnabled := eq (include "keda.enabled" . | trim) "true" -}}
+{{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
 {{- if .Values.ingress.reverseProxy.enabled }}
 {{- $srvHttp = printf "%s-nginx" (include "adhoc-odoo.serviceNameSuffix" .) }}
 {{- $srvWs = printf "%s-nginx" (include "adhoc-odoo.serviceNameSuffix" .) }}
 {{- end }}
-{{- if $isKedaEnabled }}
-# Si KEDA está habilitado, enruta a través del interceptor para aprovechar el autoescalado basado en métricas de tráfico
+{{- if and $isKedaEnabled (not $isWakeupEnabled) }}
+# Si KEDA está habilitado (sin wakeup controller), enruta a través del interceptor para aprovechar el autoescalado basado en métricas de tráfico
 # Usamos siempre .svc.cluster.local para evitar problemas de resolución de DNS dentro del cluster, especialmente con KEDA
 # Aunque el verdadero sea .svc.cluster01.local por limitaciones de istio
 {{- $srvHttp = "keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local" }}

--- a/charts/adhoc-odoo/templates/scaler/keda.yaml
+++ b/charts/adhoc-odoo/templates/scaler/keda.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "keda.enabled" . | trim) "true" }}
+{{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -13,7 +14,7 @@ spec:
   initialCooldownPeriod: 900 # Initial period before scaling 15 min
   cooldownPeriod: 900
   triggers:
-    {{- if eq (.Values.autoscaling.minReplicas | toString | int) 0 }}
+    {{- if and (eq (.Values.autoscaling.minReplicas | toString | int) 0) (not $isWakeupEnabled) }}
     - type: external-push
       metadata:
         scalerAddress: "keda-add-ons-http-external-scaler.keda:9090"
@@ -32,7 +33,7 @@ spec:
           }[2m]))
     {{- end }}
 
-{{- if eq (.Values.autoscaling.minReplicas | toString | int) 0 }}
+{{- if and (eq (.Values.autoscaling.minReplicas | toString | int) 0) (not $isWakeupEnabled) }}
 ---
 apiVersion: http.keda.sh/v1beta1
 kind: InterceptorRoute

--- a/charts/adhoc-odoo/templates/validate.yaml
+++ b/charts/adhoc-odoo/templates/validate.yaml
@@ -31,3 +31,18 @@ Debe existir nombre de base de datos.
 {{- if not .Values.odoo.pg.db -}}
 {{- fail "You must set .Values.odoo.pg.db to a valid database name." -}}
 {{- end -}}
+
+{{- /*
+wakeupController requiere controllerSvc y minReplicas=0.
+*/ -}}
+{{- if .Values.autoscaling.wakeupController.enabled -}}
+{{- if eq (.Values.autoscaling.wakeupController.controllerSvc | default "") "" -}}
+{{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.wakeupController.controllerSvc to be set (use the FQDN from the adhoc-wakeup-controller chart NOTES)." -}}
+{{- end -}}
+{{- if ne (.Values.autoscaling.minReplicas | int) 0 -}}
+{{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.minReplicas=0 (scale-to-zero mode)." -}}
+{{- end -}}
+{{- if not .Values.autoscaling.keda.enabled -}}
+{{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.keda.enabled=true." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -216,7 +216,7 @@ ingress:
     image:
       # repository: nginx
       repository: dockerhub.adhoc.inc/adhoc/ops-tools
-      tag: "odooEdgeProxy-2026.05.21.1"
+      tag: "odooEdgeProxy-2026.06.05.13"
     loadBalancerCIDR: 10.0.0.0/8
     internalClusterCIDR: 10.0.0.0/8
     # Monitoring
@@ -255,6 +255,15 @@ autoscaling:
   keda:
     enabled: false
     rpsThreshold: 2
+
+  # Wakeup controller (requiere autoscaling.keda.enabled=true y minReplicas=0)
+  # Reemplaza el HTTP interceptor de KEDA con un servidor de espera propio.
+  wakeupController:
+    enabled: false
+    # FQDN del servicio del controlador (salida del chart adhoc-wakeup-controller).
+    # Ejemplo: adhoc-wakeup-controller.adhoc-wakeup-controller.svc.cluster.local
+    controllerSvc: ""
+    controllerPort: 9080
 
 nodeSelector: {}
 tolerations: {}

--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -1,0 +1,22 @@
+annotations:
+  category: DevOps
+apiVersion: v2
+name: adhoc-wakeup-controller
+description: >
+  Controlador de wakeup para instancias Odoo con scale-to-zero en Kubernetes.
+  Reemplaza el HTTP interceptor de KEDA como frontend visible al usuario
+  durante cold start. Sirve una página de espera genérica, dispara el escalado
+  0→1 y restaura el ruteo del VirtualService de Istio cuando Odoo está listo.
+
+type: application
+
+version: 0.1.0
+
+appVersion: "odooWakeupController-latest"
+
+home: "https://github.com/adhoc-dev/helm-charts"
+sources:
+  - "https://github.com/adhoc-dev/devops-ops-tools"
+maintainers:
+  - name: azacchino
+    email: az@adhoc.inc

--- a/charts/adhoc-wakeup-controller/templates/NOTES.txt
+++ b/charts/adhoc-wakeup-controller/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Adhoc Wakeup Controller deployed.
+
+Controller service FQDN (use as wakeupController.controllerSvc in adhoc-odoo):
+  {{ include "adhoc-wakeup-controller.serviceFQDN" . }}
+
+To enable the wakeup controller for an Odoo instance, set in adhoc-odoo values:
+  autoscaling:
+    keda:
+      enabled: true
+    wakeupController:
+      enabled: true
+      controllerSvc: {{ include "adhoc-wakeup-controller.serviceFQDN" . }}

--- a/charts/adhoc-wakeup-controller/templates/_helpers.tpl
+++ b/charts/adhoc-wakeup-controller/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "adhoc-wakeup-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "adhoc-wakeup-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "adhoc-wakeup-controller.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "adhoc-wakeup-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "adhoc-wakeup-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "adhoc-wakeup-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name
+*/}}
+{{- define "adhoc-wakeup-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "adhoc-wakeup-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+FQDN of the waiting-page service (used by adhoc-odoo as CONTROLLER_SVC annotation).
+*/}}
+{{- define "adhoc-wakeup-controller.serviceFQDN" -}}
+{{- printf "%s.%s.svc.cluster.local" (include "adhoc-wakeup-controller.fullname" .) .Release.Namespace }}
+{{- end }}

--- a/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
+++ b/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "adhoc-wakeup-controller.fullname" . }}
+  labels:
+    {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
+rules:
+  # Read & patch Deployments (scale to 1, update annotations)
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+  # Scale subresource (replica count)
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch"]
+  # Read pods to detect readiness
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  # Read services (resolve service names)
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "endpointslices"]
+    verbs: ["get", "list"]
+  # Update Istio VirtualServices
+  # "update" = PUT (replace_namespaced_custom_object), "patch" = PATCH (no longer used
+  # but kept for compatibility). Both verbs are needed for full VS management.
+  - apiGroups: ["networking.istio.io"]
+    resources: ["virtualservices"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  # Emit Kubernetes events for observability
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # kopf requires access to its own CRD status storage
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # kopf watches namespaces to discover new ones in clusterwide mode.
+  # Without this, kopf falls back to a degraded mode that may cause startup errors.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  # KEDA ScaledObjects: pause/unpause during wakeup to prevent KEDA from
+  # immediately scaling back to 0 before Prometheus reflects real traffic.
+  # "update" covers replace_namespaced_custom_object (PUT).
+  - apiGroups: ["keda.sh"]
+    resources: ["scaledobjects"]
+    verbs: ["get", "list", "update"]

--- a/charts/adhoc-wakeup-controller/templates/clusterrolebinding.yaml
+++ b/charts/adhoc-wakeup-controller/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "adhoc-wakeup-controller.fullname" . }}
+  labels:
+    {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "adhoc-wakeup-controller.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "adhoc-wakeup-controller.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/adhoc-wakeup-controller/templates/deployment.yaml
+++ b/charts/adhoc-wakeup-controller/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adhoc-wakeup-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "adhoc-wakeup-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "adhoc-wakeup-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "adhoc-wakeup-controller.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: controller
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: PROMETHEUS_URL
+              value: {{ .Values.prometheusUrl | quote }}
+            - name: CONTROLLER_SVC
+              value: {{ include "adhoc-wakeup-controller.serviceFQDN" . | quote }}
+            - name: CONTROLLER_PORT
+              value: {{ .Values.service.port | quote }}
+            - name: IDLE_RPS_THRESHOLD
+              value: {{ .Values.idleRpsThreshold | quote }}
+            - name: IDLE_CONSECUTIVE_THRESHOLD
+              value: {{ .Values.idleConsecutiveThreshold | quote }}
+            - name: WAKEUP_TIMEOUT
+              value: {{ .Values.wakeupTimeoutSeconds | quote }}
+            - name: REFRESH_SECONDS
+              value: {{ .Values.refreshSeconds | quote }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/adhoc-wakeup-controller/templates/service.yaml
+++ b/charts/adhoc-wakeup-controller/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adhoc-wakeup-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "adhoc-wakeup-controller.selectorLabels" . | nindent 4 }}

--- a/charts/adhoc-wakeup-controller/templates/serviceaccount.yaml
+++ b/charts/adhoc-wakeup-controller/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "adhoc-wakeup-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,0 +1,43 @@
+image:
+  repository: docker.io/adhoc/ops-tools
+  tag: odooWakeupController-latest
+  pullPolicy: Always
+
+replicaCount: 1
+
+# Kubernetes namespace where the controller is deployed.
+# Odoo instances must be able to reach the controller service from their namespace.
+namespace: adhoc-wakeup-controller
+
+service:
+  port: 9080
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+# Prometheus endpoint the controller queries for idle detection.
+prometheusUrl: "http://prometheus-operated.monitoring:9090"
+
+# RPS below which an instance is considered idle.
+idleRpsThreshold: "0.1"
+# Number of consecutive 60-second checks below idleRpsThreshold before scale-down.
+idleConsecutiveThreshold: "12"
+# Seconds to wait for Odoo pod to become ready during wakeup (default: 5 min).
+wakeupTimeoutSeconds: "300"
+# Suggested refresh interval for the waiting page (seconds).
+refreshSeconds: "5"
+
+serviceAccount:
+  create: true
+  name: ""
+
+podAnnotations: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Qué hace

Agrega el chart `adhoc-wakeup-controller` y extiende `adhoc-odoo` para soportar el nuevo mecanismo de scale-to-zero con página de espera propia.

## Chart adhoc-wakeup-controller (nuevo)

Controller cluster-wide que reemplaza el HTTP interceptor de KEDA como frontend visible durante cold start. Deployment + Service + ServiceAccount + ClusterRole (permisos para VS update, KEDA pause/unpause, Deployments scale).

## Cambios en adhoc-odoo

| Archivo | Cambio |
|---|---|
| `values.yaml` | Nuevo bloque `autoscaling.wakeupController` (enabled, controllerSvc, controllerPort) |
| `_helpers.tpl` | Helper `wakeupController.enabled` |
| `deployment.yaml` | Anotaciones `wakeup.adhoc.inc/*` cuando wakeupController activo |
| `virtualService.yaml` | No rutar al interceptor KEDA cuando wakeupController habilitado |
| `scaler/keda.yaml` | Omite `InterceptorRoute`, usa trigger Prometheus en lugar de external-push |
| `validate.yaml` | 3 validaciones: controllerSvc vacío, minReplicas != 0, keda deshabilitado |

## Cómo habilitar en una instancia

```yaml
autoscaling:
  keda:
    enabled: true
  minReplicas: 0
  wakeupController:
    enabled: true
    controllerSvc: adhoc-wakeup-controller.adhoc-wakeup-controller.svc.cluster.local
```

## Repos relacionados

- Imagen del controller: `ingadhoc/devops-ops-tools` (PR separado)
- Pulumi infra: `ingadhoc/devops-cloud-infra` (PR separado)

Task: https://www.adhoc.inc/odoo/project/task/69043