### PR TITLE
feat: agregar CRD WakeupInstance y actualizar adhoc-odoo

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -12,21 +12,14 @@ metadata:
   name: {{ include "adhoc-odoo.fullname" . }}
   labels:
     {{- include "adhoc-odoo.labels" . | nindent 4 }}
+    {{- if $isWakeupEnabled }}
+    "wakeup.adhoc.inc/managed": "true"
+    {{- end }}
   annotations:
     certmanager.k8s.io/disable-auto-restart: "true"
     "kubernetes.io/change-cause": {{ .Values.changeCause | quote }}
     "adhoc.ar/dev-name": "" # Used to identify the developer that deployed the app
     "adhoc.ar/dev-r2cmd": "" # Used to store the r2cmd command to redeploy the app
-    {{- if $isWakeupEnabled }}
-    "wakeup.adhoc.inc/managed": "true"
-    "wakeup.adhoc.inc/state": "ready"
-    "wakeup.adhoc.inc/vs-shared": {{ printf "%s-shared" .Values.odoo.pg.db | quote }}
-    "wakeup.adhoc.inc/vs-custom": {{ ternary (printf "%s-custom" .Values.odoo.pg.db) "" (ne .Values.ingress.istio.altHosts "") | quote }}
-    "wakeup.adhoc.inc/svc-host": {{ $svcHost | quote }}
-    "wakeup.adhoc.inc/svc-port": "80"
-    "wakeup.adhoc.inc/ws-host": {{ ternary (printf "%s-websocket" $fullName) "" (gt (.Values.odoo.performance.workers | toString | int) 0) | quote }}
-    "wakeup.adhoc.inc/instance": {{ .Values.odoo.pg.db | quote }}
-    {{- end }}
 spec:
   {{- if not (or .Values.autoscaling.hpa.enabled $isKedaEnabled) }}
   replicas: {{ .Values.replicaCount | int }}

--- a/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
+++ b/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
@@ -1,7 +1,7 @@
 {{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
 {{- $fullName := include "adhoc-odoo.serviceNameSuffix" . -}}
 {{- $svcHost := ternary (printf "%s-nginx" $fullName) (printf "%s-http" $fullName) .Values.ingress.reverseProxy.enabled -}}
-{{- if $isWakeupEnabled }}
+{{- if and $isWakeupEnabled (.Capabilities.APIVersions.Has "wakeup.adhoc.inc/v1") }}
 apiVersion: wakeup.adhoc.inc/v1
 kind: WakeupInstance
 metadata:

--- a/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
+++ b/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
@@ -1,0 +1,20 @@
+{{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
+{{- $fullName := include "adhoc-odoo.serviceNameSuffix" . -}}
+{{- $svcHost := ternary (printf "%s-nginx" $fullName) (printf "%s-http" $fullName) .Values.ingress.reverseProxy.enabled -}}
+{{- if $isWakeupEnabled }}
+apiVersion: wakeup.adhoc.inc/v1
+kind: WakeupInstance
+metadata:
+  name: {{ include "adhoc-odoo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-odoo.labels" . | nindent 4 }}
+spec:
+  deploymentName: {{ include "adhoc-odoo.fullname" . }}
+  vsShared: {{ printf "%s-shared" .Values.odoo.pg.db | quote }}
+  vsCustom: {{ ternary (printf "%s-custom" .Values.odoo.pg.db) "" (ne .Values.ingress.istio.altHosts "") | quote }}
+  svcHost: {{ $svcHost | quote }}
+  svcPort: 80
+  wsHost: {{ ternary (printf "%s-websocket" $fullName) "" (gt (.Values.odoo.performance.workers | toString | int) 0) | quote }}
+  instance: {{ .Values.odoo.pg.db | quote }}
+{{- end }}

--- a/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
+++ b/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
@@ -46,3 +46,11 @@ rules:
   - apiGroups: ["keda.sh"]
     resources: ["scaledobjects"]
     verbs: ["get", "list", "update"]
+  # WakeupInstance CRD: full lifecycle — the controller owns this resource.
+  # "update" is needed for replace_namespaced_custom_object (PUT) used by kopf.
+  - apiGroups: ["wakeup.adhoc.inc"]
+    resources: ["wakeupinstances"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["wakeup.adhoc.inc"]
+    resources: ["wakeupinstances/status"]
+    verbs: ["get", "update", "patch"]

--- a/charts/adhoc-wakeup-controller/templates/crd.yaml
+++ b/charts/adhoc-wakeup-controller/templates/crd.yaml
@@ -24,6 +24,7 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required: ["spec"]
           properties:
             spec:
               type: object
@@ -31,28 +32,35 @@ spec:
                 - deploymentName
                 - vsShared
                 - svcHost
+                - instance
               properties:
                 deploymentName:
                   type: string
+                  minLength: 1
                   description: Name of the Odoo Deployment to scale up/down.
                 vsShared:
                   type: string
+                  minLength: 1
                   description: Name of the primary (shared) VirtualService.
                 vsCustom:
                   type: string
                   description: Name of the altHosts VirtualService (optional).
                 svcHost:
                   type: string
+                  minLength: 1
                   description: Real Odoo service hostname to restore routing to.
                 svcPort:
                   type: integer
                   default: 80
+                  minimum: 1
+                  maximum: 65535
                   description: Real Odoo service port.
                 wsHost:
                   type: string
                   description: Websocket service hostname (optional, for workers).
                 instance:
                   type: string
+                  minLength: 1
                   description: Odoo database/instance name (used for Prometheus query and wakeup lookup).
             status:
               type: object

--- a/charts/adhoc-wakeup-controller/templates/crd.yaml
+++ b/charts/adhoc-wakeup-controller/templates/crd.yaml
@@ -2,6 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: wakeupinstances.wakeup.adhoc.inc
+  annotations:
+    # Prevent helm uninstall from deleting the CRD (and all WakeupInstance objects).
+    # The CRD must be removed manually when the controller is decommissioned.
+    helm.sh/resource-policy: keep
   labels:
     {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
 spec:

--- a/charts/adhoc-wakeup-controller/templates/crd.yaml
+++ b/charts/adhoc-wakeup-controller/templates/crd.yaml
@@ -1,0 +1,70 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: wakeupinstances.wakeup.adhoc.inc
+  labels:
+    {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
+spec:
+  group: wakeup.adhoc.inc
+  names:
+    kind: WakeupInstance
+    plural: wakeupinstances
+    singular: wakeupinstance
+    shortNames:
+      - wi
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - deploymentName
+                - vsShared
+                - svcHost
+              properties:
+                deploymentName:
+                  type: string
+                  description: Name of the Odoo Deployment to scale up/down.
+                vsShared:
+                  type: string
+                  description: Name of the primary (shared) VirtualService.
+                vsCustom:
+                  type: string
+                  description: Name of the altHosts VirtualService (optional).
+                svcHost:
+                  type: string
+                  description: Real Odoo service hostname to restore routing to.
+                svcPort:
+                  type: integer
+                  default: 80
+                  description: Real Odoo service port.
+                wsHost:
+                  type: string
+                  description: Websocket service hostname (optional, for workers).
+                instance:
+                  type: string
+                  description: Odoo database/instance name (used for Prometheus query and wakeup lookup).
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: State
+          type: string
+          jsonPath: .status.state
+        - name: Idle-Checks
+          type: integer
+          jsonPath: .status.idleConsecutiveChecks
+        - name: Last-Wakeup
+          type: date
+          jsonPath: .status.lastWakeup
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/charts/registry-cache/templates/configmap.yaml
+++ b/charts/registry-cache/templates/configmap.yaml
@@ -24,6 +24,8 @@ data:
           dryrun: false
         readonly:
           enabled: false
+      delete:
+        enabled: true
     proxy:
       remoteurl: {{ .Values.proxy.remoteurl | quote }}
       # Mark cached content as stale after 60 days

--- a/charts/registry-cache/templates/configmap.yaml
+++ b/charts/registry-cache/templates/configmap.yaml
@@ -24,8 +24,6 @@ data:
           dryrun: false
         readonly:
           enabled: false
-      delete:
-        enabled: true
     proxy:
       remoteurl: {{ .Values.proxy.remoteurl | quote }}
       # Mark cached content as stale after 60 days


### PR DESCRIPTION
## Resumen

- `adhoc-wakeup-controller`: nuevo `crd.yaml` que define `WakeupInstance` (CRD namespaced con status subresource y printer columns). ClusterRole actualizado con permisos para `wakeup.adhoc.inc`.
- `adhoc-odoo`: nuevo template `scaler/wakeup-instance.yaml` que crea el `WakeupInstance` por release. El `deployment.yaml` pasa de 8 anotaciones `wakeup.adhoc.inc/*` a un único label estático `wakeup.adhoc.inc/managed: "true"`.

**Requiere PR hermano:** `ingadhoc/devops-ops-tools#7`

Task: https://www.adhoc.inc/odoo/project/task/69043