### PR TITLE
[FIX] OWC: minReplicaCount=1 en ScaledObject para instancias wakeup-managed

### DIFF
--- a/charts/adhoc-wakeup-controller/templates/deployment.yaml
+++ b/charts/adhoc-wakeup-controller/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: controller
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,8 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.06.08.3
+  tag: odooWakeupController-2026.06.08.5
+  # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
+  digest: ""
   pullPolicy: Always
 
 replicaCount: 1


### PR DESCRIPTION
## Cambio

Cuando `autoscaling.wakeupController.enabled=true`, el ScaledObject de KEDA ahora tiene `minReplicaCount: 1` en lugar de `{{ .Values.autoscaling.minReplicas }}` (que es 0).

## Por qué

Con la Propuesta 2 del refactor OWC ([ingadhoc/devops-ops-tools#9](https://github.com/ingadhoc/devops-ops-tools/pull/9)), el wakeup controller es dueño del tramo 0↔1. KEDA solo maneja 1↔N. Con `minReplicaCount=1`, KEDA nunca puede llevar las réplicas a 0 por sí solo, eliminando el problema de cold-start que causaba scale-to-zero inmediato al despauzarse.

La transición 1→0 la ejecuta el `idle_detector` explícitamente vía `apps_api.patch(replicas=0)` después de switchear el VirtualService.

## Deploy

Mergear junto con `ingadhoc/devops-ops-tools#9` y actualizar imagen una vez que CI construya la nueva versión.