### PR TITLE
fix: acotar permisos RBAC de weblate (wildcard → reglas específicas)

### DIFF
--- a/charts/weblate/templates/rbac.yaml
+++ b/charts/weblate/templates/rbac.yaml
@@ -1,13 +1,32 @@
-# This role grants permissions for managing deployments, viewing pod logs, executing commands in pods,
-# and viewing events and services in the namespace. It is intended for development environment access.
+# Grants admin access to the Weblate namespace for operations: restart StatefulSet,
+# view logs, exec into pods, manage CNPG cluster/backups, read Secrets, view PVCs.
+# Binding is opt-in via k8sAdmin.users (empty by default).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: admin-role
 rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec"]
+    verbs: ["get", "list", "create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "backups", "scheduledbackups"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list"]
 ---
 {{- if .Values.k8sAdmin.users }}
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Problema

`charts/weblate/templates/rbac.yaml` definía `admin-role` con `apiGroups/resources/verbs: ["*"]` — control total del namespace para cualquier usuario en `k8sAdmin.users`.

El binding es opt-in (vacío por defecto), pero con el wildcard cualquier usuario bindeado podía leer todos los Secrets, crear pods arbitrarios y modificar el CNPG Cluster.

## Cambio

Reemplazado el wildcard por reglas explícitas que cubren las operaciones reales del administrador de Weblate:

| Recurso | Verbs |
|---|---|
| `apps/statefulsets` | get, list, patch, update |
| `pods`, `pods/log`, `pods/exec` | get, list, create |
| `events`, `services` | get, list |
| `postgresql.cnpg.io/clusters,backups,scheduledbackups` | get, list, patch, update |
| `secrets` | get, list |
| `persistentvolumeclaims` | get, list |

## Verificación

```bash
helm lint charts/weblate/        # 0 errores
helm template test charts/weblate/  # Role renderiza correctamente
```

## Notas para el reviewer

- `secrets: get/list` es necesario para gestión de SSH keys y credenciales — si se considera excesivo, puede eliminarse y agregarse on-demand.
- El RoleBinding sigue siendo opt-in (`k8sAdmin.users: []` por defecto) — no cambia comportamiento en instalaciones existentes sin usuarios configurados.