### PR TITLE
fix: restringir NetworkPolicy CNPG a pods clientes legítimos

### DIFF
--- a/charts/adhoc-odoo/templates/cnpg/networkPolicy.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/networkPolicy.yaml
@@ -12,9 +12,14 @@ spec:
     - Ingress
   ingress:
     - from:
-        # Allow all traffic from the same namespace
-        - podSelector: {}
-            # matchLabels:
-            #     adhoc.ar/app-name: "odoo"
+        - podSelector:
+            matchLabels:
+              adhoc.ar/app-name: "odoo"
+        - podSelector:
+            matchLabels:
+              adhoc.ar/app-name: "odoo-fixdb"
+        - podSelector:
+            matchLabels:
+              adhoc.ar/app-name: "odoo-wait-pg"
 
 {{- end }}

--- a/charts/adhoc-odoo/templates/cnpg/waitPg.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/waitPg.yaml
@@ -11,6 +11,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        adhoc.ar/app-name: "odoo-wait-pg"
     spec:
       restartPolicy: Never
       {{- if eq .Values.adhoc.appType "prod" }}


### PR DESCRIPTION
## Problema

La NetworkPolicy de CNPG usaba `podSelector: {}`, permitiendo que **cualquier pod del namespace** alcance PostgreSQL. En un namespace de cliente eso incluye nginx, KEDA scalers y cualquier sidecar futuro que no necesita acceso a la base de datos.

## Fix

Reemplaza el selector permisivo por tres entradas explícitas:

- `adhoc.ar/app-name: "odoo"` — pods de Odoo
- `adhoc.ar/app-name: "odoo-fixdb"` — job de fix de base de datos
- `adhoc.ar/app-name: "odoo-wait-pg"` — job de espera de disponibilidad de PG (label agregado al pod template de `waitPg.yaml`, que antes no lo tenía)

## Validación

```
helm template + helm lint: 0 errores
```

Detectado en security review (F-07 del repo adhocsec).