### PR TITLE
fix: pinear GitHub Actions a SHA completo (supply chain)

### DIFF
--- a/.github/workflows/helm-dev.yml
+++ b/.github/workflows/helm-dev.yml
@@ -19,21 +19,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: 'src'
           ref: 'dev'
           fetch-depth: 0
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: 'dest'
           ref: 'gh-pages'
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
 
       - name: Publish Helm Charts
         shell: bash

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
           echo "changed_count=$(wc -l < changed_files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 
@@ -70,7 +70,7 @@ jobs:
         run: yamllint -c .yamllint .
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
 
       - name: Helm validate (lint + template)
         shell: bash

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -19,21 +19,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: 'src'
           ref: 'main'
           fetch-depth: 0
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: 'dest'
           ref: 'gh-pages'
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
 
       - name: Publish Helm Charts
         shell: bash


### PR DESCRIPTION
## Problema

Los tres workflows usan tags flotantes (`@v4`, `@v5`, `@v4.2.0`). Un tag puede ser reapuntado por el mantenedor del repositorio upstream sin aviso — un atacante que comprometa esa cuenta puede inyectar código malicioso en nuestro CI.

## Fix

Reemplaza todos los tags por SHA de commit inmutables con comentario de versión:

| Action | Antes | Después |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e114876b...` `# v4.3.1` |
| `actions/setup-python` | `@v5` | `@a26af69be9...` `# v5.6.0` |
| `azure/setup-helm` | `@v4.2.0` | `@fe7b79cd5e...` `# v4.2.0` |

Afecta: `helm.yml`, `helm-dev.yml`, `helm-validate.yml`.

Detectado en security review (F-04 del repo adhocsec).