### PR TITLE
feat: parametrizar cnpg.io/hibernation en el chart adhoc-odoo

### DIFF
--- a/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/name: {{ include "cnpg.sanitizedPgName" . }}-pg
     {{- include "adhoc-odoo.labels" . | nindent 4 }}
   annotations:
-    cnpg.io/hibernation: "off"
+    cnpg.io/hibernation: {{ .Values.cloudNativePG.hibernation | default "off" | quote }}
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     {{- /*
     # For manual intervention

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -372,6 +372,11 @@ cloudNativePG:
   checkCRD: false
   enabled: false
   version: "15.0"
+  # Declarative CNPG hibernation. "off" keeps the cluster running; "on"
+  # shuts down the PostgreSQL pods while keeping the PVCs. The SaaS provider
+  # sets this to "on" when a database is inactivated (see saas_k8s
+  # _k8s_inactivate) and back to "off" on reactivation. See cnpg/pgcluster.yaml.
+  hibernation: "off"
   superUserPassword: Rgd20sGT5JKUheTbRM5VWW4sDSLHJjzh6P3JwAqtRrsnURCKzPbX4FNJ5fGWwgh8
   resources:
     requests:


### PR DESCRIPTION
La annotation del Cluster CNPG pasa a leerse de cloudNativePG.hibernation (default "off"), permitiendo que el SaaS provider hiberne la base al inactivarla (saas_k8s _k8s_inactivate). Sin bump de versión: el default mantiene el comportamiento idéntico, el cambio es neutral.

Tarea #69414