### PR TITLE
chore: esperar PostgreSQL desde el entrypoint y quitar init container wait-for-postgres

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -82,13 +82,9 @@ spec:
       terminationGracePeriodSeconds: {{ ternary 120 60 (eq .Values.adhoc.appType "prod") }}
       {{- end }}
       serviceAccountName: {{ include "adhoc-odoo.serviceAccountName" . }}
-      initContainers:
-      {{- if .Values.cloudNativePG.enabled }}
-        - name: wait-for-postgres
-          image: "ghcr.io/cloudnative-pg/postgresql:{{ .Values.cloudNativePG.version | default "15.0" }}"
-          command: ['sh', '-c', 'until pg_isready -h {{ include "cnpg.sanitizedPgName" . }}-pg-rw -p {{ .Values.odoo.pg.port | default 5432 }}; do echo "Esperando a que PostgreSQL esté listo..."; sleep 2; done']
-      {{- end }}
+      {{- /* La espera de PostgreSQL la maneja el entrypoint (WAIT_PG=true); ya no hay init container wait-for-postgres */}}
       {{- if .Values.adhoc.devMode }}
+      initContainers:
         - name: seed-vscode-server
           image: adhoc/ops-tools:vscode-sidecar-latest
           imagePullPolicy: Always

--- a/charts/adhoc-odoo/templates/odooEnvs.yaml
+++ b/charts/adhoc-odoo/templates/odooEnvs.yaml
@@ -100,7 +100,8 @@ data:
   DISABLE_SESSION_GC: "true"
   */}}
   {{- /* Entrypoint */}}
-  WAIT_PG: "false"
+  {{- /* El entrypoint espera a PostgreSQL (reemplaza al init container wait-for-postgres) */}}
+  WAIT_PG: "true"
   {{- if .Values.odoo.entrypoint.fixdbs }}
   FIXDBS: {{ .Values.odoo.entrypoint.fixdbs | quote }}
   {{- end }}


### PR DESCRIPTION
## Qué

Reemplaza el init container `wait-for-postgres` por el mecanismo de espera del propio entrypoint de la imagen odoo (`WAIT_PG=true`).

- `odooEnvs.yaml`: `WAIT_PG` pasa a `"true"`.
- `deployment.yaml`: se elimina el init container `wait-for-postgres`; `initContainers` queda solo para devMode.

## Por qué

El entrypoint ya espera a PostgreSQL cuando `WAIT_PG=true`, así que el init container es redundante. Cambio **interno al chart, sin dependencia con el código del provider**: aplicable a cualquier base independientemente de la versión de saas_k8s.

## Notas

- **No se bumpea la versión del chart** (queda 0.3.4) por indicación del equipo.
- Parte de la tarea 69411 (separada del cambio de fixdb para poder rolearla de forma independiente).