### PR TITLE
chore: fixdb siempre como Job, apagar FIXDBS/FIXDBS_ADHOC en el entrypoint

### DIFF
--- a/charts/adhoc-odoo/questions.yml
+++ b/charts/adhoc-odoo/questions.yml
@@ -297,20 +297,6 @@ questions:
     required: false
     default: "template0"
 # Entrypoint Odoo-SaaS
-  - variable: odoo.entrypoint.fixdbs
-    group: "Entrypoint"
-    label: "FIX DBS (click-odoo-update)"
-    description: "Try to fix database before starting odoo."
-    type: "boolean"
-    default: false
-    required: false
-  - variable: odoo.entrypoint.fixdbsAdhoc
-    group: "Entrypoint"
-    label: "FIX DBS AdHoc"
-    description: "Try to fix database before starting odoo."
-    type: "boolean"
-    default: true
-    required: false
   - variable: odoo.entrypoint.repos
     group: "Entrypoint"
     label: "Git Aggregator repos.yml"

--- a/charts/adhoc-odoo/templates/odooEnvs.yaml
+++ b/charts/adhoc-odoo/templates/odooEnvs.yaml
@@ -102,12 +102,11 @@ data:
   {{- /* Entrypoint */}}
   {{- /* El entrypoint espera a PostgreSQL (reemplaza al init container wait-for-postgres) */}}
   WAIT_PG: "true"
-  {{- if .Values.odoo.entrypoint.fixdbs }}
-  FIXDBS: {{ .Values.odoo.entrypoint.fixdbs | quote }}
-  {{- end }}
-  {{- if .Values.odoo.entrypoint.fixdbsAdhoc }}
-  FIXDBS_ADHOC: {{ .Values.odoo.entrypoint.fixdbsAdhoc | quote }}
-  {{- end }}
+  {{- /* fixdb nunca corre por el entrypoint: siempre corre como Job standalone
+         lanzado por el pipeline de saas_k8s (tarea 69411). Se deja apagado de
+         forma permanente vía env. */}}
+  FIXDBS: "false"
+  FIXDBS_ADHOC: "false"
   FIX_DB_WEB_DISABLED: "true"
   {{- /* Dynamic Entrypoint */}}
   {{- if .Values.odoo.entrypoint.repos }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -304,8 +304,8 @@ odoo:
     maxTimeCron: 6000
     maxHttpTh: 8
   entrypoint:
-    fixdbs: false
-    fixdbsAdhoc: true
+    # fixdb corre siempre como Job standalone (saas_k8s), nunca por el entrypoint.
+    # FIXDBS / FIXDBS_ADHOC quedan apagados de forma permanente en odooEnvs.yaml.
     # Dynamic Entrypoint
     repos: ""
     custom: ""


### PR DESCRIPTION
## Qué

fixdb deja de correr por el entrypoint del pod: ahora corre siempre como **Job standalone** lanzado por el pipeline de saas_k8s (tarea 69411).

- `odooEnvs.yaml`: `FIXDBS` y `FIXDBS_ADHOC` hardcodeados en `"false"`.
- `values.yaml` / `questions.yml`: se quitan las keys `odoo.entrypoint.fixdbs` / `fixdbsAdhoc`.

## Acoplamiento

Requiere la versión de saas_k8s que corre fixdb como Job (PR de odoo-saas, tarea 69411). **Desplegar primero el código del provider y recién después disponibilizar este chart** (un chart con fixdb apagado + código viejo saltearía el fixdb non-exclusive). El override transitorio en saas_k8s neutraliza el flag en cualquier versión de chart, así que la ventana es segura.

## Notas

- Apilado sobre el PR de wait-pg (#69); este PR muestra solo el diff de fixdb. Retargetear a `main` cuando #69 mergee.
- **No se bumpea la versión del chart** (queda 0.3.4) por indicación del equipo.