### PR TITLE
fix: OWC — bump imagen a 2026.06.17.13 (reconcile drift ready/scaled-to-zero)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,7 +10,7 @@ description: >
 
 type: application
 
-version: 0.2.1
+version: 0.2.2
 
 appVersion: "odooWakeupController-latest"
 

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.06.11.11
+  tag: odooWakeupController-2026.06.17.13
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump del chart `adhoc-wakeup-controller` 0.2.1 → 0.2.2 apuntando a la imagen `odooWakeupController-2026.06.17.13` (build de main de [ingadhoc/devops-ops-tools#15](https://github.com/ingadhoc/devops-ops-tools/pull/15)).

El fix agrega reconciliación level-triggered en el wakeup controller: sana instancias atascadas en `ready` con el Deployment escalado a 0 por fuera del controller (KEDA minReplicaCount=0 manual, operador). Validado en vivo en cluster01.

Al mergear, el workflow `helm.yml` publica el chart 0.2.2 a gh-pages. Después se bumpea `chartVersion` en devops-cloud-infra (Pulumi.prod-apps.yaml) y `pulumi up`.