### PR TITLE
feat: opt-in para hibernar CNPG cuando la base duerme (wakeup controller)

### DIFF
--- a/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
+++ b/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
@@ -17,4 +17,8 @@ spec:
   svcPort: 80
   wsHost: {{ ternary (printf "%s-websocket" $fullName) "" (gt (.Values.odoo.performance.workers | toString | int) 0) | quote }}
   instance: {{ .Values.odoo.pg.db | quote }}
+  {{- if and .Values.cloudNativePG.enabled (.Values.autoscaling.wakeupController.hibernateCnpg | default false) }}
+  hibernateCnpg: true
+  cnpgCluster: {{ printf "%s-pg" (include "cnpg.sanitizedPgName" .) | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -264,6 +264,11 @@ autoscaling:
     # Ejemplo: adhoc-wakeup-controller.platform.svc
     controllerSvc: "adhoc-wakeup-controller.platform.svc"
     controllerPort: 9080
+    # Opt-in: hibernar el cluster CNPG asociado cuando la instancia duerme.
+    # Solo aplica si cloudNativePG.enabled=true. Ahorra el pod de PostgreSQL
+    # mientras la base está dormida, a costa de un wakeup más lento (resume de
+    # PostgreSQL antes de levantar Odoo).
+    hibernateCnpg: false
 
 nodeSelector: {}
 tolerations: {}

--- a/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
+++ b/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
@@ -54,3 +54,10 @@ rules:
   - apiGroups: ["wakeup.adhoc.inc"]
     resources: ["wakeupinstances/status"]
     verbs: ["get", "update", "patch"]
+  # CNPG Clusters: hibernate/resume the PostgreSQL cluster backing a sleeping
+  # instance (opt-in via WakeupInstance.spec.hibernateCnpg). "get" reads the
+  # cluster + polls its status; "update" covers replace_namespaced_custom_object
+  # (PUT) used to set the cnpg.io/hibernation annotation.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "update"]

--- a/charts/adhoc-wakeup-controller/templates/crd.yaml
+++ b/charts/adhoc-wakeup-controller/templates/crd.yaml
@@ -62,6 +62,13 @@ spec:
                   type: string
                   minLength: 1
                   description: Odoo database/instance name (used for Prometheus query and wakeup lookup).
+                hibernateCnpg:
+                  type: boolean
+                  default: false
+                  description: Whether to hibernate the backing CNPG cluster when the instance sleeps (opt-in).
+                cnpgCluster:
+                  type: string
+                  description: Name of the CNPG Cluster CR to hibernate/resume (same namespace). Required when hibernateCnpg is true.
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Qué

Habilita que el Odoo Wakeup Controller hiberne el cluster CNPG cuando la base duerme (scale-to-zero), complementando la hibernación que ya ocurre al *inactivar* la base (annotation `cnpg.io/hibernation` parametrizada, ya en `main`).

Lado-chart de la mejora; la lógica vive en el controller (`ingadhoc/devops-ops-tools#17`). **Sin bump de versión** (cambio backward-compatible: campos opcionales del CRD + value con default false).

## Cambios

**`adhoc-wakeup-controller`**
- CRD `WakeupInstance`: campos opcionales `hibernateCnpg` (bool, default false) y `cnpgCluster` (string).
- RBAC: `get`/`update` sobre `clusters.postgresql.cnpg.io`.

**`adhoc-odoo`**
- Value `autoscaling.wakeupController.hibernateCnpg` (default false).
- `wakeup-instance.yaml`: setea `hibernateCnpg` + `cnpgCluster` (`<release saneado>-pg`) gated por `cloudNativePG.enabled` y el flag. Default → sin cambios.

## Test plan

- `helm lint` OK en ambos charts.
- `helm template` del `wakeup-instance.yaml`: con `cloudNativePG.enabled=true` + `hibernateCnpg=true` emite `cnpgCluster: <release>-pg`; con cualquiera en false, no emite los campos.
- pre-commit (yamllint + helm validate) OK.

## Refs

- Controller: ingadhoc/devops-ops-tools#17
- Spec: `ingadhoc/devops-project` (PR #7).
- Tarea: https://www.adhoc.inc/odoo/project/164/tasks/69682