### PR TITLE
OWC: keda desactivado deshabilita el wakeup controller (sin abortar el render)

### DIFF
--- a/charts/adhoc-odoo/changelog.md
+++ b/charts/adhoc-odoo/changelog.md
@@ -36,6 +36,8 @@ Improvements:
   - Safer upgrades and rollbacks using Helm-managed values
 - Istio:
   - new config to allow legacy http01 requests (`ingress.istio.http10.enabled`)
+- Autoscaling (OWC):
+  - keda is a prerequisite for the wakeup controller: disabling keda now disables OWC automatically instead of failing the render (the `wakeupController.enabled` helper already gated on keda; removed the hard `fail` in `validate.yaml`)
 
 ## *0.3.3*
 

--- a/charts/adhoc-odoo/templates/validate.yaml
+++ b/charts/adhoc-odoo/templates/validate.yaml
@@ -33,16 +33,16 @@ Debe existir nombre de base de datos.
 {{- end -}}
 
 {{- /*
-wakeupController requiere controllerSvc y minReplicas=0.
+wakeupController: keda es prerrequisito, pero no es un error tenerlo apagado.
+Si keda está desactivado, el wakeup controller queda deshabilitado
+automáticamente (lo resuelve el helper "wakeupController.enabled"), así que su
+configuración solo se valida cuando keda está efectivamente activo.
 */ -}}
-{{- if .Values.autoscaling.wakeupController.enabled -}}
+{{- if and .Values.autoscaling.wakeupController.enabled (eq (include "keda.enabled" . | trim) "true") -}}
 {{- if eq (.Values.autoscaling.wakeupController.controllerSvc | default "") "" -}}
 {{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.wakeupController.controllerSvc to be set (use the FQDN from the adhoc-wakeup-controller chart NOTES)." -}}
 {{- end -}}
 {{- if ne (.Values.autoscaling.minReplicas | int) 0 -}}
 {{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.minReplicas=0 (scale-to-zero mode)." -}}
-{{- end -}}
-{{- if not .Values.autoscaling.keda.enabled -}}
-{{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.keda.enabled=true." -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Qué

En el chart `adhoc-odoo`, la activación del wakeup controller (OWC) tenía a keda como **requerimiento duro**: con OWC activo y keda desactivado, el render abortaba con `fail` en `validate.yaml`.

Este cambio invierte la lógica: **si keda está desactivado, OWC queda deshabilitado automáticamente** (no es error).

## Por qué funciona sin tocar nada más

El helper `wakeupController.enabled` (`_helpers.tpl`) ya exigía `keda.enabled`, y todos los consumidores (deployment, ScaledObject de keda, virtualService, WakeupInstance) pasan por ese helper. La UI también ocultaba el toggle de OWC con `show_if: keda.enabled=true`. Lo único que convertía "keda off + owc on" en un error duro era el `fail` — el runtime ya se comportaba bien.

## Cambios

- `templates/validate.yaml`: se elimina el `fail` de "requires keda.enabled=true". Las validaciones de config de OWC (`controllerSvc`, `minReplicas=0`) ahora solo corren cuando keda está efectivamente activo (helper `keda.enabled`).
- `changelog.md`: nota bajo 0.3.4. **Sin bump de versión** (Chart.yaml queda en 0.3.4).

## Test plan (`helm template`)

| Escenario | Antes | Ahora |
|---|---|---|
| keda **off** + owc on | render falla | renderiza, 0 recursos OWC/keda |
| keda on + owc on bien config | WakeupInstance | WakeupInstance (sin cambios) |
| keda on + owc on **sin** controllerSvc | falla | sigue fallando (guardrail intacto) |

Verificado con `pre-commit` (yamllint + helm lint/template).

tarea 69683