### PR TITLE
feat: dominio configurable para correr un OWC canary en el mismo cluster

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -198,3 +198,13 @@ and minReplicas is 0 (scale-to-zero mode).
     (ne (.Values.autoscaling.wakeupController.controllerSvc | default "") "")
 -}}
 {{- end -}}
+
+{{/*
+wakeupController.domain — CRD group / managed-label prefix of the controller this
+instance is attached to. Default "wakeup.adhoc.inc" (stable). Set to a canary
+domain (e.g. "wakeup-canary.adhoc.inc") together with a matching canary install of
+adhoc-wakeup-controller to shadow-test a new OWC build. See OWC doc/canary-testing.md.
+*/}}
+{{- define "wakeupController.domain" -}}
+{{- .Values.autoscaling.wakeupController.domain | default "wakeup.adhoc.inc" -}}
+{{- end -}}

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     {{- include "adhoc-odoo.labels" . | nindent 4 }}
     {{- if $isWakeupEnabled }}
-    "wakeup.adhoc.inc/managed": "true"
+    {{ printf "%s/managed" (include "wakeupController.domain" .) | quote }}: "true"
     {{- end }}
   annotations:
     certmanager.k8s.io/disable-auto-restart: "true"

--- a/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
+++ b/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
@@ -1,8 +1,9 @@
 {{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
 {{- $fullName := include "adhoc-odoo.serviceNameSuffix" . -}}
 {{- $svcHost := ternary (printf "%s-nginx" $fullName) (printf "%s-http" $fullName) .Values.ingress.reverseProxy.enabled -}}
-{{- if and $isWakeupEnabled (.Capabilities.APIVersions.Has "wakeup.adhoc.inc/v1") }}
-apiVersion: wakeup.adhoc.inc/v1
+{{- $wakeupDomain := include "wakeupController.domain" . -}}
+{{- if and $isWakeupEnabled (.Capabilities.APIVersions.Has (printf "%s/v1" $wakeupDomain)) }}
+apiVersion: {{ $wakeupDomain }}/v1
 kind: WakeupInstance
 metadata:
   name: {{ include "adhoc-odoo.fullname" . }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -264,6 +264,12 @@ autoscaling:
     # Ejemplo: adhoc-wakeup-controller.platform.svc
     controllerSvc: "adhoc-wakeup-controller.platform.svc"
     controllerPort: 9080
+    # CRD group / managed-label prefix del controller al que se engancha esta
+    # instancia. Default = el controller "stable". Para shadow-testear un build
+    # nuevo de OWC, apuntá la instancia a un controller "canary" seteando esto al
+    # mismo dominio del install canary (ej. "wakeup-canary.adhoc.inc") y
+    # controllerSvc al Service del canary. Ver OWC doc/canary-testing.md.
+    domain: "wakeup.adhoc.inc"
 
 nodeSelector: {}
 tolerations: {}

--- a/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
+++ b/charts/adhoc-wakeup-controller/templates/clusterrole.yaml
@@ -47,10 +47,12 @@ rules:
     resources: ["scaledobjects"]
     verbs: ["get", "list", "update"]
   # WakeupInstance CRD: full lifecycle — the controller owns this resource.
+  # apiGroup is the configurable domain so a canary release (distinct domain)
+  # gets RBAC on its own CRD group; default keeps the stable identity.
   # "update" is needed for replace_namespaced_custom_object (PUT) used by kopf.
-  - apiGroups: ["wakeup.adhoc.inc"]
+  - apiGroups: [{{ .Values.domain | quote }}]
     resources: ["wakeupinstances"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["wakeup.adhoc.inc"]
+  - apiGroups: [{{ .Values.domain | quote }}]
     resources: ["wakeupinstances/status"]
     verbs: ["get", "update", "patch"]

--- a/charts/adhoc-wakeup-controller/templates/crd.yaml
+++ b/charts/adhoc-wakeup-controller/templates/crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: wakeupinstances.wakeup.adhoc.inc
+  name: wakeupinstances.{{ .Values.domain }}
   annotations:
     # Prevent helm uninstall from deleting the CRD (and all WakeupInstance objects).
     # The CRD must be removed manually when the controller is decommissioned.
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
 spec:
-  group: wakeup.adhoc.inc
+  group: {{ .Values.domain }}
   names:
     kind: WakeupInstance
     plural: wakeupinstances

--- a/charts/adhoc-wakeup-controller/templates/deployment.yaml
+++ b/charts/adhoc-wakeup-controller/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
+            - name: WAKEUP_DOMAIN
+              value: {{ .Values.domain | quote }}
+            - name: WAKEUP_FINALIZER
+              value: {{ .Values.finalizer | quote }}
             - name: PROMETHEUS_URL
               value: {{ .Values.prometheusUrl | quote }}
             - name: CONTROLLER_SVC

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -7,6 +7,19 @@ image:
 
 replicaCount: 1
 
+# Identity / scoping of this controller. Defaults are the canonical "stable"
+# identity. To run a parallel "canary" controller in the SAME cluster (e.g. to
+# test a new OWC build against a few instances without touching the stable one),
+# install a second release overriding `domain` (and `finalizer`) and point the
+# test instances at it via adhoc-odoo's `wakeupController.domain`. The two
+# controllers then watch disjoint CRD groups + managed labels and never collide.
+# See doc/canary-testing.md.
+#
+# domain drives both the CRD group (wakeupinstances.<domain>) and the
+# managed-label prefix (<domain>/managed) the controller watches.
+domain: "wakeup.adhoc.inc"
+finalizer: "wakeup-controller.adhoc.inc/finalizer"
+
 # Kubernetes namespace where the controller is deployed.
 # Odoo instances must be able to reach the controller service from their namespace.
 namespace: adhoc-wakeup-controller


### PR DESCRIPTION
## Qué

Lado-chart del mecanismo canary de OWC: permite enganchar una instancia Odoo a un controller OWC **canary** (build a probar) en vez del **stable**, para shadow-testing en el mismo cluster sin tocar prod. Controller: ingadhoc/devops-ops-tools#18.

Defaults = stable → un deploy sin overrides queda idéntico al actual. **Sin bump de versión** (cambio backward-compatible).

## Cambios

**`adhoc-wakeup-controller`**
- Value `domain` (default `wakeup.adhoc.inc`) → CRD `wakeupinstances.<domain>` + `spec.group`; envs `WAKEUP_DOMAIN`/`WAKEUP_FINALIZER` al Deployment. Value `finalizer`.
- Un segundo `helm install` con `domain` distinto = controller canary aislado (CRD, ClusterRole/Binding, Service propios por release name).

**`adhoc-odoo`**
- Value `autoscaling.wakeupController.domain` (helper `wakeupController.domain`).
- El `WakeupInstance` usa `apiVersion: <domain>/v1` + capability check; el Deployment de Odoo el label `<domain>/managed`. Apuntando `domain` + `controllerSvc` al canary, la instancia queda gobernada por el canary y el stable no la ve.

## Test plan

- `helm lint` OK en ambos charts.
- `helm template` verificado en **ambos flavors**: stable (default) emite `wakeup.adhoc.inc/v1` + `wakeup.adhoc.inc/managed` (sin cambios); canary (`domain=wakeup-canary.adhoc.inc`) emite `wakeup-canary.adhoc.inc/v1`, label `wakeup-canary.adhoc.inc/managed`, CRD `wakeupinstances.wakeup-canary.adhoc.inc`.
- pre-commit (yamllint + helm validate) OK.

## Refs

- Controller + doc operativa (`doc/canary-testing.md`): ingadhoc/devops-ops-tools#18