### PR TITLE
chore: adhoc-wakeup-controller 0.3.0 + imagen nueva (CNPG hibernation + canary)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.2.2
+version: 0.3.0
 
-appVersion: "odooWakeupController-latest"
+appVersion: "odooWakeupController-2026.06.21.18"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.06.17.13
+  tag: odooWakeupController-2026.06.21.18
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump del chart del controller a 0.3.0 con la imagen `odooWakeupController-2026.06.21.18` (CNPG hibernation #17 + canary #18, probado en cluster01). Habilita actualizar el OWC stable vía Pulumi (chartVersion 0.3.0).