### PR TITLE
fix: OWC — helpers wakeupController.* toleran sub-map nil (regresión #74)

### DIFF
--- a/charts/adhoc-odoo/changelog.md
+++ b/charts/adhoc-odoo/changelog.md
@@ -2,6 +2,15 @@
 
 ## *0.3.4*
 
+Fixes:
+
+- OWC (wakeup controller): los helpers `wakeupController.domain` y
+  `wakeupController.enabled` ahora toleran que el sub-map
+  `autoscaling.wakeupController` venga nil/ausente (caso típico: `helm upgrade
+  --reuse-values` sobre una instancia legacy anterior a #74). Antes el render
+  fallaba con `nil pointer evaluating interface {}.domain`. Regresión cubierta
+  por el fixture `ci/legacy-no-wakeupcontroller-values.yaml`.
+
 Features:
 
 - Reverse Proxy:

--- a/charts/adhoc-odoo/ci/legacy-no-wakeupcontroller-values.yaml
+++ b/charts/adhoc-odoo/ci/legacy-no-wakeupcontroller-values.yaml
@@ -1,0 +1,10 @@
+# Regresión OWC (#74): instancia legacy cuyos values reusados (helm upgrade
+# --reuse-values desde un release pre-wakeupController) NO traen el sub-map
+# autoscaling.wakeupController. Antes del fix, los helpers wakeupController.*
+# nil-pointeaban al dereferenciar .domain/.enabled sobre un mapa nil.
+# Debe renderizar sin error (wakeup queda deshabilitado, WakeupInstance vacío).
+autoscaling:
+  minReplicas: 1
+  keda:
+    enabled: false
+  wakeupController: null

--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -191,11 +191,12 @@ wakeupController.enabled — true when KEDA + wakeup controller are both active
 and minReplicas is 0 (scale-to-zero mode).
 */}}
 {{- define "wakeupController.enabled" -}}
+{{- $wc := .Values.autoscaling.wakeupController | default dict -}}
 {{- and
     (eq (include "keda.enabled" . | trim) "true")
-    (.Values.autoscaling.wakeupController.enabled | default false)
+    ($wc.enabled | default false)
     (eq (.Values.autoscaling.minReplicas | int) 0)
-    (ne (.Values.autoscaling.wakeupController.controllerSvc | default "") "")
+    (ne ($wc.controllerSvc | default "") "")
 -}}
 {{- end -}}
 
@@ -206,5 +207,6 @@ domain (e.g. "wakeup-canary.adhoc.inc") together with a matching canary install 
 adhoc-wakeup-controller to shadow-test a new OWC build. See OWC doc/canary-testing.md.
 */}}
 {{- define "wakeupController.domain" -}}
-{{- .Values.autoscaling.wakeupController.domain | default "wakeup.adhoc.inc" -}}
+{{- $wc := .Values.autoscaling.wakeupController | default dict -}}
+{{- $wc.domain | default "wakeup.adhoc.inc" -}}
 {{- end -}}

--- a/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
+++ b/charts/adhoc-odoo/templates/scaler/wakeup-instance.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "adhoc-odoo.serviceNameSuffix" . -}}
 {{- $svcHost := ternary (printf "%s-nginx" $fullName) (printf "%s-http" $fullName) .Values.ingress.reverseProxy.enabled -}}
 {{- $wakeupDomain := include "wakeupController.domain" . -}}
+{{- $wc := .Values.autoscaling.wakeupController | default dict -}}
 {{- if and $isWakeupEnabled (.Capabilities.APIVersions.Has (printf "%s/v1" $wakeupDomain)) }}
 apiVersion: {{ $wakeupDomain }}/v1
 kind: WakeupInstance
@@ -18,7 +19,7 @@ spec:
   svcPort: 80
   wsHost: {{ ternary (printf "%s-websocket" $fullName) "" (gt (.Values.odoo.performance.workers | toString | int) 0) | quote }}
   instance: {{ .Values.odoo.pg.db | quote }}
-  {{- if and .Values.cloudNativePG.enabled (.Values.autoscaling.wakeupController.hibernateCnpg | default false) }}
+  {{- if and .Values.cloudNativePG.enabled ($wc.hibernateCnpg | default false) }}
   hibernateCnpg: true
   cnpgCluster: {{ printf "%s-pg" (include "cnpg.sanitizedPgName" .) | quote }}
   {{- end }}

--- a/charts/adhoc-odoo/templates/validate.yaml
+++ b/charts/adhoc-odoo/templates/validate.yaml
@@ -38,8 +38,9 @@ Si keda está desactivado, el wakeup controller queda deshabilitado
 automáticamente (lo resuelve el helper "wakeupController.enabled"), así que su
 configuración solo se valida cuando keda está efectivamente activo.
 */ -}}
-{{- if and .Values.autoscaling.wakeupController.enabled (eq (include "keda.enabled" . | trim) "true") -}}
-{{- if eq (.Values.autoscaling.wakeupController.controllerSvc | default "") "" -}}
+{{- $wc := .Values.autoscaling.wakeupController | default dict -}}
+{{- if and ($wc.enabled | default false) (eq (include "keda.enabled" . | trim) "true") -}}
+{{- if eq ($wc.controllerSvc | default "") "" -}}
 {{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.wakeupController.controllerSvc to be set (use the FQDN from the adhoc-wakeup-controller chart NOTES)." -}}
 {{- end -}}
 {{- if ne (.Values.autoscaling.minReplicas | int) 0 -}}

--- a/scripts/helm-validate-charts.sh
+++ b/scripts/helm-validate-charts.sh
@@ -80,6 +80,18 @@ for chart in "${charts[@]}"; do
   echo "==> helm template ${chart##$repo_root/}" >&2
   helm template "$chart" >/dev/null
 
+  # Fixtures de CI (convención chart-testing): cada ci/*-values.yaml es un set
+  # de values que el chart debe renderizar sin error. Sirven como regresión de
+  # casos que el render con values default no ejercita (ej. sub-maps nil).
+  if [[ -d "$chart/ci" ]]; then
+    shopt -s nullglob
+    for fixture in "$chart"/ci/*-values.yaml; do
+      echo "==> helm template ${chart##$repo_root/} -f ${fixture##$repo_root/}" >&2
+      helm template "$chart" -f "$fixture" >/dev/null
+    done
+    shopt -u nullglob
+  fi
+
 done
 
 echo >&2


### PR DESCRIPTION
## Problema

El `helm upgrade` del chart `adhoc-odoo` falla para instancias legacy (caso real: **catalogoneored** en `adhocprod`) con:

```
_helpers.tpl:209:11 executing "wakeupController.domain"
  at <.Values.autoscaling.wakeupController.domain>:
    nil pointer evaluating interface {}.domain
```

**Causa raíz** — regresión introducida en #74: el helper `wakeupController.domain` dereferencia `.Values.autoscaling.wakeupController.domain` sin tolerar que el sub-map venga `nil`/ausente. En un `helm upgrade --reuse-values` sobre un release anterior a #74 (que nunca tuvo el bloque `wakeupController`), el sub-map no existe → panic. El `| default` no salva porque el panic ocurre en el deref, antes del default. No es exclusivo de catalogoneored: cualquier instancia legacy upgradeada con values reusados rompe igual.

## Fix

Endurecidos los tres sitios que dereferencian el sub-map, con el patrón nil-safe `.Values.autoscaling.wakeupController | default dict`:

- **`_helpers.tpl`** — `wakeupController.domain` (el que rompía) y `wakeupController.enabled` (bug latente, hoy salvado solo por el short-circuit de `and`).
- **`validate.yaml`** — chequeo de `controllerSvc` / `minReplicas`.
- **`scaler/wakeup-instance.yaml`** — flag `hibernateCnpg` (#72), ya protegido por el guard `$isWakeupEnabled` pero endurecido por consistencia.

## Regresión

- Fixture `ci/legacy-no-wakeupcontroller-values.yaml` (`wakeupController: null`).
- `scripts/helm-validate-charts.sh` ahora renderiza todo `ci/*-values.yaml`, así el CI ejercita el caso que el render con values default no tocaba.

## Verificación

`helm lint` + `helm template` + pre-commit en verde. 4 escenarios:

- `wakeupController: null` → render sin panic ✅
- domain canary (`wakeup-canary.adhoc.inc`) se respeta ✅
- domain default (`wakeup.adhoc.inc`) ✅
- path `hibernateCnpg` ✅

**Hotfix sobre 0.3.4 — sin bump de versión.**

## Desbloqueo inmediato (sin esperar el merge)

```
helm upgrade ... --set autoscaling.wakeupController.domain=wakeup.adhoc.inc
```
