### PR TITLE
feat: token CICD como value dedicado, solo con aggregate (tarea 69695)

### DIFF
--- a/charts/adhoc-odoo/ci/entrypoint-token-values.yaml
+++ b/charts/adhoc-odoo/ci/entrypoint-token-values.yaml
@@ -1,0 +1,16 @@
+# Regresión tarea 69695: con `entrypoint.repos` no vacío, el token del bot CICD
+# (`entrypoint.githubBotToken`) debe renderizarse como GITHUB_BOT_TOKEN en el
+# ConfigMap *-common-envs. El caso "sin repos => sin token" lo cubre el render
+# con values default (repos: "" => GITHUB_BOT_TOKEN ausente).
+# Debe renderizar sin error.
+odoo:
+  entrypoint:
+    repos: |
+      ./odoo/custom/src:
+        ingadhoc/odoo-private:
+          remotes:
+            origin: https://github.com/ingadhoc/odoo-private.git
+          target: origin 19.0
+          merges:
+            - origin 19.0
+    githubBotToken: "ghs-fixture-token-do-not-use"

--- a/charts/adhoc-odoo/templates/odooEnvs.yaml
+++ b/charts/adhoc-odoo/templates/odooEnvs.yaml
@@ -111,6 +111,10 @@ data:
   {{- /* Dynamic Entrypoint */}}
   {{- if .Values.odoo.entrypoint.repos }}
   REPOS_YAML: {{ .Values.odoo.entrypoint.repos | quote }}
+  {{- /* Anidado en `if repos` a propósito: sin aggregate no se expone el token. */}}
+  {{- if .Values.odoo.entrypoint.githubBotToken }}
+  GITHUB_BOT_TOKEN: {{ .Values.odoo.entrypoint.githubBotToken | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.odoo.entrypoint.custom }}
   CUSTOM_CONFIG: {{ .Values.odoo.entrypoint.custom | quote }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -320,6 +320,8 @@ odoo:
     # Dynamic Entrypoint
     repos: ""
     custom: ""
+    # Token del bot CICD; se inyecta como GITHUB_BOT_TOKEN solo si `repos` no está vacío.
+    githubBotToken: ""
   # SMTP Config
   smtp:
     host: ""

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -139,8 +139,10 @@ odoo:
   entrypoint:
     fixdbs: false
     fixdbsAdhoc: true
-    repos: ""      # repos adicionales a clonar en el entrypoint
-    custom: ""     # scripts custom del entrypoint
+    repos: ""           # repos adicionales a clonar en el entrypoint
+    custom: ""          # scripts custom del entrypoint
+    githubBotToken: ""  # token del bot CICD; se inyecta como GITHUB_BOT_TOKEN
+                        # solo si `repos` no está vacío
 
   smtp:
     host: ""


### PR DESCRIPTION
## Qué

El token del bot CICD deja de viajar por el mapa genérico `odoo.extraEnvVars`
y pasa a ser un value dedicado `odoo.entrypoint.githubBotToken`, que se
renderiza como `GITHUB_BOT_TOKEN` en el ConfigMap `*-common-envs` **solo
cuando `odoo.entrypoint.repos` no está vacío** (queda anidado dentro del
`if repos` en `odooEnvs.yaml`).

## Por qué

Hoy `GITHUB_BOT_TOKEN` se renderiza incondicionalmente: aunque la instancia no
tenga repos para agregar (sin aggregate), el token queda disponible en el
ConfigMap y en el env del pod. El git-aggregator del entrypoint solo necesita
el token cuando hay repos privados que clonar; sin repos no hay razón para
exponerlo.

Cubre el ítem "borrar token de CICD si no hay PRs agregados" de la tarea 69695.

## Cambios

- `charts/adhoc-odoo/templates/odooEnvs.yaml`: `GITHUB_BOT_TOKEN` anidado dentro
  del `if repos`.
- `charts/adhoc-odoo/values.yaml`: nuevo `odoo.entrypoint.githubBotToken: ""`.
- `doc/adhoc-odoo.md`: documentación del value.
- `charts/adhoc-odoo/ci/entrypoint-token-values.yaml`: fixture de regresión.

Sin bump de versión (se versiona aparte).

## Test plan

`helm template` sobre el chart:

| Caso | Resultado esperado |
|---|---|
| `repos:""` + token seteado | `GITHUB_BOT_TOKEN` **ausente** |
| `repos` seteado + token | `REPOS_YAML` + `GITHUB_BOT_TOKEN` presentes |
| `repos` seteado, sin token | `REPOS_YAML` presente, token ausente |
| values default | ambos ausentes |

`bash scripts/helm-validate-charts.sh charts/adhoc-odoo` (lint + template +
fixtures) pasa.

## Follow-up (otro repo)

El consumidor que arma los values ya pobla `odoo.entrypoint.githubBotToken`.
Tras mergear esto, se retira `GITHUB_BOT_TOKEN` del path viejo (`extraEnvVars`)
para que el único camino sea el condicionado.
