### PR TITLE
chore: bump adhoc-wakeup-controller a 0.3.1 (OWC 2026.06.23.20)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
-appVersion: "odooWakeupController-2026.06.21.18"
+appVersion: "odooWakeupController-2026.06.23.20"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.06.21.18
+  tag: odooWakeupController-2026.06.23.20
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Publica la versión del Odoo Wakeup Controller con los fixes de resiliencia (tarea 69747, PR ingadhoc/devops-ops-tools#21):

- **404 ante WakeupInstance eliminada** (teardown): `patch_wi_status` trata el 404 como no-op + done-callback dueño de errores en las tasks fire-and-forget.
- **Drift de ruteo post-restore**: reconciler simétrico `_reconcile_running_but_waiting` que restaura el VS a Odoo cuando el Deployment está ready pero el VS quedó en la waiting page.

Solo cambia `appVersion` + `image.tag` → `odooWakeupController-2026.06.23.20` (imagen de main). El template del chart no cambia, por eso es bump patch (`0.3.0 → 0.3.1`).

**Validación:** imagen probada end-to-end como canary en cluster01 contra una base real (rojo→verde). `pre-commit` (yamllint + helm validate) verde.