### PR TITLE
fix: PROMETHEUS_MULTIPROC_DIR solo con workers>0 (threaded crasheaba /metrics)

### DIFF
--- a/charts/adhoc-odoo/templates/odooEnvs.yaml
+++ b/charts/adhoc-odoo/templates/odooEnvs.yaml
@@ -177,7 +177,10 @@ data:
   ODOO_MAX_HTTP_THREADS: "8"
   ODOO_SESSION_REDIS_SSL: "0"
   LITELLM_LOG: "CRITICAL"
+  {{- /* multiprocess only makes sense with workers>0; setting it threaded crashes prometheus_client on a missing dir */}}
+  {{- if gt $workers 0 }}
   PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_client"
+  {{- end }}
   KWKHTMLTOPDF_SERVER_URL: {{ .Values.odoo.kwkhtmltopdfServerUrl | quote }}
   {{- if $isKedaEnabled }}
   ADHOC_TRUST_ON_IP_HEADER: HTTP_X_ENVOY_EXTERNAL_ADDRESS


### PR DESCRIPTION
## Qué

Gatea `PROMETHEUS_MULTIPROC_DIR` en el configmap de Odoo para que se setee **solo con `workers > 0`**.

## Por qué

`prometheus_client` entra en modo multiproceso únicamente por la presencia de `PROMETHEUS_MULTIPROC_DIR` en el env — no mira `workers`. El configmap lo seteaba **incondicionalmente**. En un deploy **threaded** (`workers=0`) el módulo `saas_prometheus` no crea ese directorio (solo lo hacía con `workers>0`), así que la primera escritura de cualquier métrica reventaba con `FileNotFoundError: /tmp/prometheus_client/gauge_max_1.db` y tiraba abajo todo el endpoint `/metrics` (500).

El multiproceso solo tiene sentido con varios procesos (`workers>0`); en threaded el modo single-process de prometheus_client alcanza y no necesita el dir.

## Test

- `helm template --set odoo.performance.workers=0` → `PROMETHEUS_MULTIPROC_DIR` **ausente**.
- `helm template --set odoo.performance.workers=2` → `PROMETHEUS_MULTIPROC_DIR` **presente**.
- pre-commit (yamllint + helm lint/template) en verde.

## Notas

- Sin bump de `version` del chart: el cambio es backward-compatible (con `workers>0` el render no cambia).
- Complementario al hardening en `saas_prometheus` (ingadhoc/odoo-saas#829), que además crea el dir si el env var llega seteado igual.
