### PR TITLE
chore: bump adhoc-wakeup-controller a 0.3.2 (OWC 2026.06.24.22)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.3.1
+version: 0.3.2
 
-appVersion: "odooWakeupController-2026.06.23.20"
+appVersion: "odooWakeupController-2026.06.24.22"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.06.23.20
+  tag: odooWakeupController-2026.06.24.22
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Publica la **iteración** del reconciler de drift de ruteo (tarea 69747, PR ingadhoc/devops-ops-tools#23):

- El reconciler `_reconcile_running_but_waiting` ahora cura el drift *"Deployment ready pero VS en waiting"* también con `state=SCALED_TO_ZERO` (antes solo `READY`). `check_idle` lo evalúa antes del gate `state != READY`.

Solo cambia `appVersion` + `image.tag` → `odooWakeupController-2026.06.24.22` (imagen de main). Template del chart sin cambios → bump patch `0.3.1 → 0.3.2`.

**Validación:** canary en cluster01 sobre el testigo `demo-18-06-38` (state `scaled-to-zero` + pod ready + VS en waiting → restaurado a Odoo, shared + custom). Rojo→verde. `pre-commit` (yamllint + helm validate) verde.