### PR TITLE
feat: flag ingress.istio.logEgress — Telemetry de egress (sin bloquear)

### DIFF
--- a/charts/adhoc-odoo/questions.yml
+++ b/charts/adhoc-odoo/questions.yml
@@ -506,6 +506,13 @@ questions:
     type: "boolean"
     required: false
     default: false
+  - variable: ingress.istio.logEgress
+    group: "Ingress"
+    label: "Log Egress Traffic"
+    description: "Log outbound (egress) traffic in JSON to discover external hosts before enabling blockOutboundTraffic. Does not block."
+    type: "boolean"
+    required: false
+    default: false
   - variable: ingress.istio.http10.enabled
     group: "Ingress"
     label: "Allow HTTP/1.0 in Istio"

--- a/charts/adhoc-odoo/templates/odoo/in-istio/telemetry-egress.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/telemetry-egress.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.ingress.istio.enabled .Values.ingress.istio.logEgress -}}
+# Telemetry de egress: loguea el tráfico saliente del namespace (workload como
+# CLIENT) usando el provider `envoy` (ya configurado a nivel mesh con
+# accessLogEncoding: JSON + el campo `sni`). Objetivo: descubrir qué hosts externos
+# usa el namespace ANTES de activar el firewall de egress (blockOutboundTraffic).
+# NO bloquea nada — la conectividad (ALLOW_ANY) queda intacta.
+#
+# Se separa del Telemetry de `logAll` (que loguea todo el tráfico) para poder
+# prender solo el egress, con menos volumen.
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: access-logging-egress
+spec:
+  accessLogging:
+    - providers:
+        - name: envoy
+      # CLIENT = el workload actuando como cliente → tráfico outbound (egress).
+      # (Telemetry usa CLIENT/SERVER/CLIENT_AND_SERVER; no SIDECAR_OUTBOUND.)
+      match:
+        mode: CLIENT
+      # Sin filtro: capturamos todo el egress del namespace para el inventario.
+      # Para acotar a solo tráfico externo y bajar volumen/costo, se puede sumar
+      # (expresión CEL a validar contra la versión de Istio del cluster):
+      #   filter:
+      #     expression: 'xds.cluster_name == "PassthroughCluster"'
+{{- end }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -61,6 +61,9 @@ ingress:
       # - "www.googleapis.com"
       # - "api.mercadolibre.com"
     logAll: false
+    # Loguea el tráfico de egress (workload como CLIENT) en JSON para descubrir qué
+    # hosts externos usa el namespace, previo a activar blockOutboundTraffic. No bloquea.
+    logEgress: false
     http10:
       enabled: false
 


### PR DESCRIPTION
## Qué

Nuevo flag `ingress.istio.logEgress` (default `false`) en el chart `adhoc-odoo`. Con `true` crea un `Telemetry` `access-logging-egress`:

```yaml
spec:
  accessLogging:
    - providers:
        - name: envoy        # ya emite JSON a nivel mesh
      match:
        mode: CLIENT          # CLIENT = workload como cliente → egress (outbound)
```

Archivos:
- `values.yaml` — `ingress.istio.logEgress: false`
- `questions.yml` — pregunta del flag
- `templates/odoo/in-istio/telemetry-egress.yaml` — el `Telemetry` (nuevo)

## Por qué

Pieza 2 del logging de egress para **descubrir qué hosts externos usan los workloads antes de activar el firewall** (`blockOutboundTraffic` / REGISTRY_ONLY). Se separa del `Telemetry` de `logAll` para prender solo egress, con menos volumen.

## Compatibilidad

- **Opt-in, default `false`** → instancias existentes no cambian.
- **Aditivo, backward-compatible** → sin bump de versión del chart (decisión deliberada para garantizar compatibilidad de `helm upgrade --reuse-values`).
- **No bloquea nada** — `ALLOW_ANY` intacto; es solo observabilidad.

## Dependencia

Para ver el host destino en egress TLS passthrough hace falta el campo `sni` en el `accessLogFormat` de istiod → `ingadhoc/devops-cloud-infra#17`. Sin eso, el log de egress muestra IP + `PassthroughCluster` pero no el hostname.

## Validación

- `helm lint` + `helm template` (pre-commit `helm-validate-charts`) ✅
- Render con `logEgress=true` produce el `Telemetry`; con `false`, nada.

## Contexto

Spec: `ingadhoc/devops-project#16`.