### PR TITLE
feat: exponer /metrics del OWC para scraping (PodMonitor)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,7 +10,7 @@ description: >
 
 type: application
 
-version: 0.3.2
+version: 0.4.0
 
 appVersion: "odooWakeupController-2026.06.24.22"
 

--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -12,7 +12,7 @@ type: application
 
 version: 0.4.0
 
-appVersion: "odooWakeupController-2026.06.24.22"
+appVersion: "odooWakeupController-2026.06.25.26"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/templates/deployment.yaml
+++ b/charts/adhoc-wakeup-controller/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
+              protocol: TCP
           env:
             - name: WAKEUP_DOMAIN
               value: {{ .Values.domain | quote }}
@@ -52,6 +55,8 @@ spec:
               value: {{ .Values.wakeupTimeoutSeconds | quote }}
             - name: REFRESH_SECONDS
               value: {{ .Values.refreshSeconds | quote }}
+            - name: METRICS_PORT
+              value: {{ .Values.metricsPort | quote }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/adhoc-wakeup-controller/templates/podmonitor.yaml
+++ b/charts/adhoc-wakeup-controller/templates/podmonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "adhoc-wakeup-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-wakeup-controller.labels" . | nindent 4 }}
+    {{- with .Values.metrics.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "adhoc-wakeup-controller.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+{{- end }}

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -27,6 +27,23 @@ namespace: adhoc-wakeup-controller
 service:
   port: 9080
 
+# Prometheus /metrics endpoint, on a separate port from the waiting page (9080)
+# so it is not reachable via the VirtualService. Scraped by the PodMonitor below.
+metricsPort: 9081
+
+metrics:
+  podMonitor:
+    # Requires the prometheus-operator PodMonitor CRD AND an OWC image that serves
+    # /metrics (feat/owc-metrics onwards). Disabled by default so deploying the
+    # chart with an older image (or on a cluster without the operator) doesn't
+    # create a PodMonitor that scrapes a closed port. Enable for the canary and
+    # once the metrics image is promoted to stable.
+    enabled: false
+    interval: 30s
+    # Extra labels so the cluster's Prometheus selects this PodMonitor (must match
+    # its podMonitorSelector, e.g. {release: kube-prometheus-stack}).
+    additionalLabels: {}
+
 resources:
   requests:
     cpu: 50m

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.06.24.22
+  tag: odooWakeupController-2026.06.25.26
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always
@@ -27,21 +27,16 @@ namespace: adhoc-wakeup-controller
 service:
   port: 9080
 
-# Prometheus /metrics endpoint, on a separate port from the waiting page (9080)
-# so it is not reachable via the VirtualService. Scraped by the PodMonitor below.
+# /metrics endpoint on a port separate from the waiting page (not exposed via the VS).
 metricsPort: 9081
 
+# Prometheus scraping of /metrics. Requires the PodMonitor CRD (prometheus-operator);
+# additionalLabels must match the cluster Prometheus's podMonitorSelector (e.g.
+# {release: prom}). Enabled per-deployment (e.g. in the Pulumi values).
 metrics:
   podMonitor:
-    # Requires the prometheus-operator PodMonitor CRD AND an OWC image that serves
-    # /metrics (feat/owc-metrics onwards). Disabled by default so deploying the
-    # chart with an older image (or on a cluster without the operator) doesn't
-    # create a PodMonitor that scrapes a closed port. Enable for the canary and
-    # once the metrics image is promoted to stable.
     enabled: false
     interval: 30s
-    # Extra labels so the cluster's Prometheus selects this PodMonitor (must match
-    # its podMonitorSelector, e.g. {release: kube-prometheus-stack}).
     additionalLabels: {}
 
 resources:


### PR DESCRIPTION
## Qué

Expone el endpoint `/metrics` del **adhoc-wakeup-controller** para que Prometheus lo scrapee. Es la pieza de chart (Fase 6) que acompaña a la instrumentación del controller en [ingadhoc/devops-ops-tools#24](https://github.com/ingadhoc/devops-ops-tools/pull/24), según la spec `wakeup-controller-metrics.md` (tarea #69684).

## Cambios (`charts/adhoc-wakeup-controller`)

- **deployment**: containerPort `metrics` (9081) + env `METRICS_PORT`.
- **values**: `metricsPort: 9081` + bloque `metrics.podMonitor` (`enabled` / `interval` / `additionalLabels`).
- **templates/podmonitor.yaml** *(nuevo)*: `PodMonitor` gated por `metrics.podMonitor.enabled`.
- **Chart.yaml**: `0.3.2` → `0.4.0`.

## Seguridad del default

`podMonitor.enabled=false` por default a propósito:
- Requiere una imagen del OWC que sirva `/metrics` (`feat/owc-metrics` en adelante) y el CRD `PodMonitor` del prometheus-operator.
- Con la imagen actual de stable nada escucha en 9081, así que crear un PodMonitor scrapearía un puerto cerrado. Los cambios al Deployment (containerPort + env) son inocuos con la imagen vieja.
- Se habilita explícito para el **canary** (`--set metrics.podMonitor.enabled=true`) y, cuando la imagen con métricas se promueva a stable, se flipea el default + se bumpea `appVersion`.

## Test plan

- `helm lint`: OK
- `helm template` default → **0 PodMonitor** (gated off); Deployment con containerPort 9081 + `METRICS_PORT`.
- `helm template --set metrics.podMonitor.enabled=true` → PodMonitor renderiza con `additionalLabels`, selector correcto, `port: metrics`, `path: /metrics`.
- pre-commit (yamllint + helm validate): OK

## Siguiente

Habilita el canary para validar las métricas end-to-end (build de imagen `feat/owc-metrics` → `helm install` del controller canary con dominio aislado + `podMonitor.enabled=true`).