### PR TITLE
feat: EnvoyFilter tls_inspector para capturar SNI en egress

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-sni-inspector.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-sni-inspector.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.ingress.istio.enabled .Values.ingress.istio.logEgress -}}
+# tls_inspector en virtualOutbound: sin él, el egress TLS en ALLOW_ANY se loguea como TCP
+# y el `sni` queda vacío. Con él, el access log de egress captura el host externo (SNI).
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: egress-sni-inspector
+spec:
+  configPatches:
+    - applyTo: LISTENER_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        listener:
+          name: virtualOutbound
+      patch:
+        operation: INSERT_FIRST
+        value:
+          name: envoy.filters.listener.tls_inspector
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+{{- end }}


### PR DESCRIPTION
## Qué

Nuevo template `templates/odoo/in-istio/egress-sni-inspector.yaml`: un `EnvoyFilter` (gateado por `ingress.istio.logEgress`, per-namespace) que agrega el listener filter `tls_inspector` al `virtualOutbound` del sidecar.

## Por qué

Complementa el `Telemetry` de egress (#81, ya mergeado). **Sin el `tls_inspector`, el egress TLS en `ALLOW_ANY` (PassthroughCluster) se loguea como TCP puro y el campo `sni` queda vacío** — solo se ve la IP destino, no el hostname. Validado en vivo sobre `test-grittiagrimensura-23-06-2` (cluster01):

- Sin el filtro: `{"sni":null,"upstream_cluster":"PassthroughCluster","upstream_host":"142.251.155.119:443"}`
- Con el filtro: `{"sni":"www.google.com","upstream_cluster":"PassthroughCluster", ...}` y `sni:"api.github.com"` — confirmado además queryable en Cloud Logging.

## El mecanismo completo de egress logging

1. `sni` en el `accessLogFormat` de istiod → `ingadhoc/devops-cloud-infra#17` (mergeado + aplicado).
2. Inyección del sidecar de Odoo → **ya en el chart** (`istio.io/rev` gateado en `istio.enabled`; PG queda afuera).
3. **`EnvoyFilter` tls_inspector → este PR.**
4. `Telemetry` egress (`match.mode: CLIENT`) → #81 (mergeado).

## Compatibilidad

Opt-in (`logEgress`, default `false`), aditivo, **sin bump de versión** del chart. No bloquea nada (ALLOW_ANY intacto).

## Caveat

`EnvoyFilter` expone internals de Envoy y puede romper entre upgrades de Istio (lo advierte Istio). Es el patrón estándar para capturar SNI en egress; este repo y `devops-cloud-infra/istio.py` ya usan EnvoyFilters. Validar tras upgrades.

## Contexto

Spec: `ingadhoc/devops-project#16`.