### PR TITLE
feat: firewall de egress — lista blanca + lista negra (prep iteración 2)

### DIFF
--- a/charts/adhoc-odoo/questions.yml
+++ b/charts/adhoc-odoo/questions.yml
@@ -499,6 +499,13 @@ questions:
     type: "listofstrings"
     default: []
     required: false
+  - variable: ingress.istio.bannedHosts
+    group: "Ingress"
+    label: "Banned Hosts"
+    description: "Hosts blocked by SNI on egress even if inside an allowedHosts wildcard (DENY over ALLOW). Only applies with blockOutboundTraffic enabled."
+    type: "listofstrings"
+    default: []
+    required: false
   - variable: ingress.istio.logAll
     group: "Ingress"
     label: "Log All Istio Ingress Traffic"

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -1,4 +1,11 @@
 {{- if and .Values.ingress.istio.enabled .Values.ingress.istio.blockOutboundTraffic -}}
+# Firewall de egress (modelo default-deny). Requiere el sidecar en REGISTRY_ONLY
+# (ver sidecar.yaml). Dos listas, ambas por SNI sobre el egressgateway:
+#   - Lista blanca (allowedHosts): únicos destinos externos alcanzables.
+#   - Lista negra (bannedHosts): excepción DENY dentro de un wildcard permitido
+#     (ej. allowedHosts: ["*.foo.com"] + bannedHosts: ["bad.foo.com"]). DENY tiene
+#     precedencia sobre ALLOW en Istio. Un host fuera de la lista blanca ya queda
+#     bloqueado por REGISTRY_ONLY, así que la lista negra solo aplica a carve-outs.
 
 {{- range $host := .Values.ingress.istio.allowedHosts }}
 # ServiceEntry: declara que el host externo existe y puede ser alcanzado.
@@ -43,8 +50,8 @@ spec:
 {{- end }}
 
 {{- if .Values.ingress.istio.allowedHosts }}
-# AuthorizationPolicy: controla qué destinos (por SNI/host) puede reenviar el egressgateway.
-# Protege al gateway actuando como firewall de salida.
+# AuthorizationPolicy (ALLOW / lista blanca): el egressgateway solo reenvía a estos
+# hosts (por SNI) cuando el origen es este namespace. Firewall de salida.
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
@@ -56,11 +63,13 @@ spec:
       istio: egressgateway
   action: ALLOW
   rules:
+  # Una sola regla: origen (este namespace) Y destino (host permitido) deben matchear.
+  # Si from y to fueran reglas separadas, Istio las OR-ea y el firewall queda abierto.
   - from:
     - source:
         namespaces:
         - "{{ .Release.Namespace }}"
-  - to:
+    to:
     - operation:
         hosts:
         {{- range .Values.ingress.istio.allowedHosts }}
@@ -69,5 +78,31 @@ spec:
 ---
 {{- end }}
 
+{{- if .Values.ingress.istio.bannedHosts }}
+# AuthorizationPolicy (DENY / lista negra): bloquea estos hosts (por SNI) aunque
+# caigan dentro de un wildcard de allowedHosts. DENY > ALLOW en Istio.
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-egress-hosts-{{ .Release.Namespace }}
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      istio: egressgateway
+  action: DENY
+  rules:
+  - from:
+    - source:
+        namespaces:
+        - "{{ .Release.Namespace }}"
+    to:
+    - operation:
+        hosts:
+        {{- range .Values.ingress.istio.bannedHosts }}
+        - "{{ . }}"
+        {{- end }}
+---
+{{- end }}
 
 {{- end }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -60,6 +60,10 @@ ingress:
     allowedHosts: []
       # - "www.googleapis.com"
       # - "api.mercadolibre.com"
+    # Lista negra: hosts bloqueados por SNI aunque caigan dentro de un allowedHosts
+    # wildcard (DENY > ALLOW). Solo aplica con blockOutboundTraffic: true.
+    bannedHosts: []
+      # - "bad.googleapis.com"
     logAll: false
     # Loguea el tráfico de egress (workload como CLIENT) en JSON para descubrir qué
     # hosts externos usa el namespace, previo a activar blockOutboundTraffic. No bloquea.


### PR DESCRIPTION
## Qué

Prepara `blockOutboundTraffic.yaml` (firewall de egress, iteración 2) para soportar **dos listas**, manteniéndolo **default off** (`blockOutboundTraffic: false`):

- **Lista blanca** (`allowedHosts`, ya existía): default-deny vía `REGISTRY_ONLY` + ServiceEntry + VirtualService + AuthorizationPolicy `ALLOW` por SNI.
- **Lista negra** (`bannedHosts`, **nuevo**): AuthorizationPolicy `action: DENY` por SNI en el egressgateway. `DENY` tiene precedencia sobre `ALLOW` → sirve para **carve-outs dentro de un wildcard permitido** (ej. `allowedHosts: ["*.foo.com"]` + `bannedHosts: ["bad.foo.com"]`).

## Fix incluido

La `AuthorizationPolicy` ALLOW tenía `from` y `to` como **reglas separadas** → Istio las OR-ea, dejando el firewall abierto (este ns a cualquier host, o cualquier origen a los hosts permitidos). Ahora van en **una sola regla** (`from` AND `to`).

## Modelo

Whitelist estricta (`REGISTRY_ONLY`): solo `allowedHosts` es alcanzable; un host fuera de la blanca ya queda bloqueado por el sidecar, así que la negra solo aplica como excepción dentro de wildcards. La lista blanca se va a poblar desde el inventario de egress (iteración 1, spec `ingadhoc/devops-project` 0007).

## Compatibilidad

Aditivo, opt-in, **sin bump de versión**. `blockOutboundTraffic: false` en todos los tenants hoy (0 ServiceEntries en los clusters) → cambio dormido, sin impacto en vivo. Capacidad lista para activar por tenant en la iteración 2.

## Pendiente (no en este PR)

- Deprecar el blacklist crudo `adhoc.dnsBannedHost` (/etc/hosts sinkhole, no-prod) en favor de este DENY Istio-native.
- Spec de iteración 2 (activación del firewall + rollout por tenant).

Archivos: `blockOutboundTraffic.yaml`, `values.yaml` (`ingress.istio.bannedHosts: []`), `questions.yml`.