### PR TITLE
feat: allowlist de egress enriquecida (IP/CIDR, TCP, SMTP, SSH-devMode)

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -67,11 +67,17 @@ spec:
         {{- end }}
         {{- end }}
         {{- $egressMode := include "adhoc-odoo.egressMode" . }}
+        {{- if and .Values.ingress.istio.enabled (or (eq $egressMode "observe") (eq $egressMode "enforce")) }}
+        {{- /* 443 NUNCA puede excluirse (en ningún modo): el HTTPS debe pasar por el sidecar para la
+           whitelist + logging SNI. Se valida el valor EFECTIVO (override de podAnnotations o el value). */}}
+        {{- $effExcl := (index (.Values.podAnnotations | default dict) "traffic.sidecar.istio.io/excludeOutboundPorts") | default (((.Values.ingress.istio.egress | default dict).excludeOutboundPorts) | default "587,465,25,22") }}
+        {{- range (splitList "," $effExcl) }}{{- if eq (trim .) "443" }}{{- fail "ingress.istio.egress.excludeOutboundPorts no puede incluir 443: el HTTPS debe pasar por el sidecar (whitelist + logging SNI). Quitá 443." }}{{- end }}{{- end }}
         {{- /* No pisar la annotation si el usuario ya la definió en podAnnotations (key duplicada). */}}
-        {{- if and .Values.ingress.istio.enabled (or (eq $egressMode "observe") (eq $egressMode "enforce")) (not (hasKey (.Values.podAnnotations | default dict) "traffic.sidecar.istio.io/excludeOutboundPorts")) }}
+        {{- if not (hasKey (.Values.podAnnotations | default dict) "traffic.sidecar.istio.io/excludeOutboundPorts") }}
         # SMTP (587/465/25) y SSH (22) son server-speaks-first: cuelgan el tls_inspector del egress
         # (logging SNI). Se sacan del sidecar y se gobiernan por NetworkPolicy. Ver doc/adhoc-odoo.md.
         traffic.sidecar.istio.io/excludeOutboundPorts: {{ (((.Values.ingress.istio.egress | default dict).excludeOutboundPorts) | default "587,465,25,22") | quote }}
+        {{- end }}
         {{- end }}
         rollme: {{ include "adhoc-odoo.releaseDigest" . }} # Force redeploy on change
         {{- if ne .Values.adhoc.appType "prod" }}

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -67,7 +67,8 @@ spec:
         {{- end }}
         {{- end }}
         {{- $egressMode := include "adhoc-odoo.egressMode" . }}
-        {{- if and .Values.ingress.istio.enabled (or (eq $egressMode "observe") (eq $egressMode "enforce")) }}
+        {{- /* No pisar la annotation si el usuario ya la definió en podAnnotations (key duplicada). */}}
+        {{- if and .Values.ingress.istio.enabled (or (eq $egressMode "observe") (eq $egressMode "enforce")) (not (hasKey (.Values.podAnnotations | default dict) "traffic.sidecar.istio.io/excludeOutboundPorts")) }}
         # SMTP (587/465/25) y SSH (22) son server-speaks-first: cuelgan el tls_inspector del egress
         # (logging SNI). Se sacan del sidecar y se gobiernan por NetworkPolicy. Ver doc/adhoc-odoo.md.
         traffic.sidecar.istio.io/excludeOutboundPorts: {{ (((.Values.ingress.istio.egress | default dict).excludeOutboundPorts) | default "587,465,25,22") | quote }}

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -66,6 +66,12 @@ spec:
         gke-gcsfuse/ephemeral-storage-request: 100Mi
         {{- end }}
         {{- end }}
+        {{- $egressMode := include "adhoc-odoo.egressMode" . }}
+        {{- if and .Values.ingress.istio.enabled (or (eq $egressMode "observe") (eq $egressMode "enforce")) }}
+        # SMTP (587/465/25) y SSH (22) son server-speaks-first: cuelgan el tls_inspector del egress
+        # (logging SNI). Se sacan del sidecar y se gobiernan por NetworkPolicy. Ver doc/adhoc-odoo.md.
+        traffic.sidecar.istio.io/excludeOutboundPorts: {{ (((.Values.ingress.istio.egress | default dict).excludeOutboundPorts) | default "587,465,25,22") | quote }}
+        {{- end }}
         rollme: {{ include "adhoc-odoo.releaseDigest" . }} # Force redeploy on change
         {{- if ne .Values.adhoc.appType "prod" }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -57,4 +57,29 @@ spec:
   resolution: NONE
 ---
 {{- end }}
+{{- /* --- 3. Puertos "abiertos a priori" (openTcpPorts): ServiceEntry wildcard por puerto -> deja
+   salir a CUALQUIER host en ese puerto, LOGUEADO por el sidecar. SOLO client-first; los
+   server-first (SMTP 587/25, SSH 22) cuelgan el tls_inspector -> van por excludeOutboundPorts. */}}
+{{- range $port := ((($egress).openTcpPorts) | default list) }}
+{{- if or (eq ($port | toString) "443") (eq ($port | toString) "80") }}
+{{- fail "ingress.istio.egress.openTcpPorts no puede incluir 80 ni 443: el 443 va por allowedHosts/allowedCidrs (whitelist) y el 80 se bloquea. Abrirlos acá anularía esos controles." }}
+{{- end }}
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: allow-egress-open-tcp-{{ $port }}
+spec:
+  # addresses 0.0.0.0/0 (no hosts "*", que Istio rechaza): matchea cualquier IP en ese puerto.
+  addresses:
+  - "0.0.0.0/0"
+  hosts:
+  - "open-tcp-{{ $port }}.egress.internal"
+  location: MESH_EXTERNAL
+  ports:
+  - number: {{ $port }}
+    name: tcp-{{ $port }}
+    protocol: TCP
+  resolution: NONE
+---
+{{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -88,6 +88,7 @@ spec:
 {{- end }}
 {{- if $smtpHost }}
 {{- $_ := set $tcpMap (printf "%s:%s" $smtpHost $smtpPort) (dict "host" $smtpHost "port" $smtpPortNum) }}
+{{- $_ := set $portOwner $smtpPort $smtpHost }}
 {{- end }}
 {{- range $key, $t := $tcpMap }}
 apiVersion: networking.istio.io/v1
@@ -106,8 +107,14 @@ spec:
 ---
 {{- end }}
 {{- /* --- 4. Git por SSH (github.com:22). Solo si repoSsh=true Y adhoc.devMode=true: es uso de
-   desarrollo, bloqueado en prod y tests comunes. Sin lista de hosts puntual. */}}
+   desarrollo, bloqueado en prod y tests comunes. Sin lista de hosts puntual.
+   github.com:22 también pasa por el guard de puerto: si otro host ya ocupa el 22 (allowedTcp /
+   odoo.smtp) falla; si github.com:22 ya vino por allowedTcp, no se duplica. */}}
 {{- if and (($egress).repoSsh) .Values.adhoc.devMode }}
+{{- if and (hasKey $portOwner "22") (ne (get $portOwner "22") "github.com") }}
+{{- fail (printf "ingress.istio.egress.repoSsh usa github.com:22 pero ya hay otro host (%s) en el puerto 22. Istio no distingue ServiceEntry TCP sin addresses en un mismo puerto: usá un único host por puerto." (get $portOwner "22")) }}
+{{- end }}
+{{- if not (hasKey $portOwner "22") }}
 apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
@@ -121,5 +128,6 @@ spec:
     name: tcp-ssh
     protocol: TCP
   resolution: DNS
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -1,12 +1,15 @@
 {{- $mode := include "adhoc-odoo.egressMode" . -}}
 {{- if and .Values.ingress.istio.enabled (eq $mode "enforce") -}}
 {{- $egress := (.Values.ingress.istio.egress | default dict) -}}
-# Whitelist de egress (enforce, deny-by-default). Bajo REGISTRY_ONLY cada destino externo
-# necesita un ServiceEntry. Tipos emitidos (ver doc/adhoc-odoo.md -> "Egress control"):
-#   1. Host/SNI  -> allowedHosts + repoHosts        (443/HTTPS, resolución DNS)
-#   2. IP/CIDR   -> allowedCidrs + baseline PGA      (443/TCP, resolución NONE) -- cubre 443 SIN SNI
-#   3. host:port -> allowedTcp + relay de odoo.smtp  (TCP, resolución DNS)      -- SMTP y otros no-443
-#   4. SSH git   -> github.com:22                    (TCP) SOLO con adhoc.devMode
+# Whitelist de egress por ServiceEntry (enforce, deny-by-default). SOLO cubre el egress que
+# atraviesa el sidecar (HTTPS/443 y TLS por IP). Bajo REGISTRY_ONLY cada destino externo necesita
+# un ServiceEntry. Tipos emitidos (ver doc/adhoc-odoo.md -> "Egress control"):
+#   1. Host/SNI -> allowedHosts + repoHosts   (443/HTTPS, resolución DNS)
+#   2. IP/CIDR  -> allowedCidrs + baseline PGA (443/TCP, resolución NONE) -- cubre 443 SIN SNI (GCS)
+#
+# SMTP (587/465/25) y SSH (22) NO van acá: son server-first y cuelgan el tls_inspector, así que se
+# sacan del sidecar (excludeOutboundPorts en odoo/deployment.yaml) y se allowlistean por CIDR en la
+# NetworkPolicy (egress-networkpolicy.yaml). Ver doc/adhoc-odoo.md -> "Egress control".
 #
 # --- 1. Hosts por SNI (HTTPS/443) ---
 {{- $hosts := (.Values.ingress.istio.allowedHosts | default list) }}
@@ -53,81 +56,5 @@ spec:
     protocol: TCP
   resolution: NONE
 ---
-{{- end }}
-{{- /* --- 3. host:puerto TCP (SMTP y otros no-443). Fuentes:
-   - allowedTcp: lista del operador. Si la clave NO está (release viejo bajo --reuse-values) se
-     usa el default de relays compartidos conocidos (Mailgun); un `allowedTcp: []` explícito SÍ
-     desactiva los defaults (por eso hasKey, no `default`, que trata [] como vacío).
-   - relay del tenant derivado de odoo.smtp: tiene prioridad — descarta cualquier otra entrada en
-     el mismo puerto (otro host), para no dejar dos ServiceEntry TCP sin addresses en un puerto
-     (Istio no podría distinguirlas). Dedup final por host:puerto. */}}
-{{- $usingDefaultTcp := not (hasKey $egress "allowedTcp") }}
-{{- $allowedTcp := list }}
-{{- if $usingDefaultTcp }}
-{{- $allowedTcp = (list (dict "host" "smtp.mailgun.org" "port" 587) (dict "host" "smtp.mailgun.org" "port" 465)) }}
-{{- else }}
-{{- $allowedTcp = ($egress.allowedTcp | default list) }}
-{{- end }}
-{{- $smtpHost := .Values.odoo.smtp.host }}
-{{- /* Alinear con odooEnvs.yaml: SMTP_PORT solo se renderiza si port != 0; sin él Odoo usa su
-   default (25). El ServiceEntry debe matchear el puerto REAL que usa Odoo, no asumir 587. */}}
-{{- $smtpPortNum := (.Values.odoo.smtp.port | default 25) }}
-{{- $smtpPort := "" }}
-{{- if $smtpHost }}{{- $smtpPort = ($smtpPortNum | toString) }}{{- end }}
-{{- $tcpMap := dict }}
-{{- $portOwner := dict }}
-{{- range $t := $allowedTcp }}
-{{- if not (and (ne $smtpPort "") (eq ($t.port | toString) $smtpPort) (ne $t.host $smtpHost)) }}
-{{- $pk := ($t.port | toString) }}
-{{- if and (hasKey $portOwner $pk) (ne (get $portOwner $pk) $t.host) }}
-{{- fail (printf "ingress.istio.egress.allowedTcp: más de un host en el puerto %s (%s y %s). Istio no distingue ServiceEntry TCP sin addresses en un mismo puerto: usá un único host por puerto." $pk (get $portOwner $pk) $t.host) }}
-{{- end }}
-{{- $_ := set $portOwner $pk $t.host }}
-{{- $_ := set $tcpMap (printf "%s:%v" $t.host $t.port) $t }}
-{{- end }}
-{{- end }}
-{{- if $smtpHost }}
-{{- $_ := set $tcpMap (printf "%s:%s" $smtpHost $smtpPort) (dict "host" $smtpHost "port" $smtpPortNum) }}
-{{- $_ := set $portOwner $smtpPort $smtpHost }}
-{{- end }}
-{{- range $key, $t := $tcpMap }}
-apiVersion: networking.istio.io/v1
-kind: ServiceEntry
-metadata:
-  name: allow-egress-tcp-{{ $t.host | replace "." "-" }}-{{ $t.port }}
-spec:
-  hosts:
-  - "{{ $t.host }}"
-  location: MESH_EXTERNAL
-  ports:
-  - number: {{ $t.port }}
-    name: tcp-{{ $t.port }}
-    protocol: TCP
-  resolution: DNS
----
-{{- end }}
-{{- /* --- 4. Git por SSH (github.com:22). Solo si repoSsh=true Y adhoc.devMode=true: es uso de
-   desarrollo, bloqueado en prod y tests comunes. Sin lista de hosts puntual.
-   github.com:22 también pasa por el guard de puerto: si otro host ya ocupa el 22 (allowedTcp /
-   odoo.smtp) falla; si github.com:22 ya vino por allowedTcp, no se duplica. */}}
-{{- if and (($egress).repoSsh) .Values.adhoc.devMode }}
-{{- if and (hasKey $portOwner "22") (ne (get $portOwner "22") "github.com") }}
-{{- fail (printf "ingress.istio.egress.repoSsh usa github.com:22 pero ya hay otro host (%s) en el puerto 22. Istio no distingue ServiceEntry TCP sin addresses en un mismo puerto: usá un único host por puerto." (get $portOwner "22")) }}
-{{- end }}
-{{- if not (hasKey $portOwner "22") }}
-apiVersion: networking.istio.io/v1
-kind: ServiceEntry
-metadata:
-  name: allow-egress-ssh-github
-spec:
-  hosts:
-  - "github.com"
-  location: MESH_EXTERNAL
-  ports:
-  - number: 22
-    name: tcp-ssh
-    protocol: TCP
-  resolution: DNS
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -62,6 +62,7 @@ spec:
    server-first (SMTP 587/25, SSH 22) cuelgan el tls_inspector -> van por excludeOutboundPorts. */}}
 {{- range $rawPort := ((($egress).openTcpPorts) | default list) }}
 {{- $port := ($rawPort | toString | trim) }}
+{{- if $port }}
 {{- if or (eq $port "443") (eq $port "80") }}
 {{- fail "ingress.istio.egress.openTcpPorts no puede incluir 80 ni 443: el 443 va por allowedHosts/allowedCidrs (whitelist) y el 80 se bloquea. Abrirlos acá anularía esos controles." }}
 {{- end }}
@@ -82,5 +83,6 @@ spec:
     protocol: TCP
   resolution: NONE
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -60,8 +60,9 @@ spec:
 {{- /* --- 3. Puertos "abiertos a priori" (openTcpPorts): ServiceEntry wildcard por puerto -> deja
    salir a CUALQUIER host en ese puerto, LOGUEADO por el sidecar. SOLO client-first; los
    server-first (SMTP 587/25, SSH 22) cuelgan el tls_inspector -> van por excludeOutboundPorts. */}}
-{{- range $port := ((($egress).openTcpPorts) | default list) }}
-{{- if or (eq ($port | toString) "443") (eq ($port | toString) "80") }}
+{{- range $rawPort := ((($egress).openTcpPorts) | default list) }}
+{{- $port := ($rawPort | toString | trim) }}
+{{- if or (eq $port "443") (eq $port "80") }}
 {{- fail "ingress.istio.egress.openTcpPorts no puede incluir 80 ni 443: el 443 va por allowedHosts/allowedCidrs (whitelist) y el 80 se bloquea. Abrirlos acá anularía esos controles." }}
 {{- end }}
 apiVersion: networking.istio.io/v1
@@ -76,7 +77,7 @@ spec:
   - "open-tcp-{{ $port }}.egress.internal"
   location: MESH_EXTERNAL
   ports:
-  - number: {{ $port }}
+  - number: {{ $port | int }}
     name: tcp-{{ $port }}
     protocol: TCP
   resolution: NONE

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -54,15 +54,32 @@ spec:
   resolution: NONE
 ---
 {{- end }}
-{{- /* --- 3. host:puerto TCP (SMTP y otros no-443). Fuentes: allowedTcp (default: relays
-   compartidos conocidos) + el relay propio del tenant (odoo.smtp). Dedup por host:puerto. */}}
+{{- /* --- 3. host:puerto TCP (SMTP y otros no-443). Fuentes:
+   - allowedTcp: lista del operador. Si la clave NO está (release viejo bajo --reuse-values) se
+     usa el default de relays compartidos conocidos (Mailgun); un `allowedTcp: []` explícito SÍ
+     desactiva los defaults (por eso hasKey, no `default`, que trata [] como vacío).
+   - relay del tenant derivado de odoo.smtp: tiene prioridad — descarta cualquier otra entrada en
+     el mismo puerto (otro host), para no dejar dos ServiceEntry TCP sin addresses en un puerto
+     (Istio no podría distinguirlas). Dedup final por host:puerto. */}}
+{{- $usingDefaultTcp := not (hasKey $egress "allowedTcp") }}
+{{- $allowedTcp := list }}
+{{- if $usingDefaultTcp }}
+{{- $allowedTcp = (list (dict "host" "smtp.mailgun.org" "port" 587) (dict "host" "smtp.mailgun.org" "port" 465)) }}
+{{- else }}
+{{- $allowedTcp = ($egress.allowedTcp | default list) }}
+{{- end }}
+{{- $smtpHost := .Values.odoo.smtp.host }}
+{{- $smtpPortNum := (.Values.odoo.smtp.port | default 587) }}
+{{- $smtpPort := "" }}
+{{- if $smtpHost }}{{- $smtpPort = ($smtpPortNum | toString) }}{{- end }}
 {{- $tcpMap := dict }}
-{{- range $t := ((($egress).allowedTcp) | default (list (dict "host" "smtp.mailgun.org" "port" 587) (dict "host" "smtp.mailgun.org" "port" 465))) }}
+{{- range $t := $allowedTcp }}
+{{- if not (and (ne $smtpPort "") (eq ($t.port | toString) $smtpPort) (ne $t.host $smtpHost)) }}
 {{- $_ := set $tcpMap (printf "%s:%v" $t.host $t.port) $t }}
 {{- end }}
-{{- if .Values.odoo.smtp.host }}
-{{- $smtpPort := (.Values.odoo.smtp.port | default 587) }}
-{{- $_ := set $tcpMap (printf "%s:%v" .Values.odoo.smtp.host $smtpPort) (dict "host" .Values.odoo.smtp.host "port" $smtpPort) }}
+{{- end }}
+{{- if $smtpHost }}
+{{- $_ := set $tcpMap (printf "%s:%s" $smtpHost $smtpPort) (dict "host" $smtpHost "port" $smtpPortNum) }}
 {{- end }}
 {{- range $key, $t := $tcpMap }}
 apiVersion: networking.istio.io/v1

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -1,16 +1,22 @@
 {{- $mode := include "adhoc-odoo.egressMode" . -}}
 {{- if and .Values.ingress.istio.enabled (eq $mode "enforce") -}}
-# Whitelist de egress (enforce, deny-by-default): un ServiceEntry 443/HTTPS por host
-# alcanzable bajo REGISTRY_ONLY. repoHosts (default github) se suman SOLO si el entrypoint
-# clona repos custom (odoo.entrypoint.repos). Ver doc/adhoc-odoo.md.
+{{- $egress := (.Values.ingress.istio.egress | default dict) -}}
+# Whitelist de egress (enforce, deny-by-default). Bajo REGISTRY_ONLY cada destino externo
+# necesita un ServiceEntry. Tipos emitidos (ver doc/adhoc-odoo.md -> "Egress control"):
+#   1. Host/SNI  -> allowedHosts + repoHosts        (443/HTTPS, resolución DNS)
+#   2. IP/CIDR   -> allowedCidrs + baseline PGA      (443/TCP, resolución NONE) -- cubre 443 SIN SNI
+#   3. host:port -> allowedTcp + relay de odoo.smtp  (TCP, resolución DNS)      -- SMTP y otros no-443
+#   4. SSH git   -> github.com:22                    (TCP) SOLO con adhoc.devMode
+#
+# --- 1. Hosts por SNI (HTTPS/443) ---
 {{- $hosts := (.Values.ingress.istio.allowedHosts | default list) }}
 {{- if .Values.odoo.entrypoint.repos }}
 {{- /* default github en el template también, para que aplique bajo --reuse-values */}}
-{{- $repoHosts := (((.Values.ingress.istio.egress | default dict).repoHosts) | default (list "github.com" "codeload.github.com" "objects.githubusercontent.com")) }}
+{{- $repoHosts := ((($egress).repoHosts) | default (list "github.com" "codeload.github.com" "objects.githubusercontent.com")) }}
 {{- $hosts = (concat $hosts $repoHosts | uniq) }}
 {{- end }}
 {{- range $host := $hosts }}
-# ServiceEntry: declara el host externo en el registry para que REGISTRY_ONLY lo permita.
+# ServiceEntry HTTPS: declara el host externo en el registry para que REGISTRY_ONLY lo permita.
 apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
@@ -25,5 +31,70 @@ spec:
     protocol: HTTPS
   resolution: DNS
 ---
+{{- end }}
+{{- /* --- 2. IP/CIDR (443 sin SNI). Baseline: VIP de Private Google Access (/30). El match es
+   por IP+puerto destino (resolution NONE -> original-dst), no por SNI: resuelve el egress a
+   GCS sin server_name. Prerequisito infra: habilitar PGA y rutear *.googleapis.com al VIP. */}}
+{{- $cidrs := (concat (list "199.36.153.8/30") ((($egress).allowedCidrs) | default list) | uniq) }}
+{{- range $cidr := $cidrs }}
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: allow-egress-cidr-{{ $cidr | replace "." "-" | replace "/" "-" }}
+spec:
+  addresses:
+  - "{{ $cidr }}"
+  hosts:
+  - "cidr-{{ $cidr | replace "." "-" | replace "/" "-" }}.egress.internal"
+  location: MESH_EXTERNAL
+  ports:
+  - number: 443
+    name: tcp-443
+    protocol: TCP
+  resolution: NONE
+---
+{{- end }}
+{{- /* --- 3. host:puerto TCP (SMTP y otros no-443). Fuentes: allowedTcp (default: relays
+   compartidos conocidos) + el relay propio del tenant (odoo.smtp). Dedup por host:puerto. */}}
+{{- $tcpMap := dict }}
+{{- range $t := ((($egress).allowedTcp) | default (list (dict "host" "smtp.mailgun.org" "port" 587) (dict "host" "smtp.mailgun.org" "port" 465))) }}
+{{- $_ := set $tcpMap (printf "%s:%v" $t.host $t.port) $t }}
+{{- end }}
+{{- if .Values.odoo.smtp.host }}
+{{- $smtpPort := (.Values.odoo.smtp.port | default 587) }}
+{{- $_ := set $tcpMap (printf "%s:%v" .Values.odoo.smtp.host $smtpPort) (dict "host" .Values.odoo.smtp.host "port" $smtpPort) }}
+{{- end }}
+{{- range $key, $t := $tcpMap }}
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: allow-egress-tcp-{{ $t.host | replace "." "-" }}-{{ $t.port }}
+spec:
+  hosts:
+  - "{{ $t.host }}"
+  location: MESH_EXTERNAL
+  ports:
+  - number: {{ $t.port }}
+    name: tcp-{{ $t.port }}
+    protocol: TCP
+  resolution: DNS
+---
+{{- end }}
+{{- /* --- 4. Git por SSH (github.com:22). Solo si repoSsh=true Y adhoc.devMode=true: es uso de
+   desarrollo, bloqueado en prod y tests comunes. Sin lista de hosts puntual. */}}
+{{- if and (($egress).repoSsh) .Values.adhoc.devMode }}
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: allow-egress-ssh-github
+spec:
+  hosts:
+  - "github.com"
+  location: MESH_EXTERNAL
+  ports:
+  - number: 22
+    name: tcp-ssh
+    protocol: TCP
+  resolution: DNS
 {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -69,12 +69,20 @@ spec:
 {{- $allowedTcp = ($egress.allowedTcp | default list) }}
 {{- end }}
 {{- $smtpHost := .Values.odoo.smtp.host }}
-{{- $smtpPortNum := (.Values.odoo.smtp.port | default 587) }}
+{{- /* Alinear con odooEnvs.yaml: SMTP_PORT solo se renderiza si port != 0; sin él Odoo usa su
+   default (25). El ServiceEntry debe matchear el puerto REAL que usa Odoo, no asumir 587. */}}
+{{- $smtpPortNum := (.Values.odoo.smtp.port | default 25) }}
 {{- $smtpPort := "" }}
 {{- if $smtpHost }}{{- $smtpPort = ($smtpPortNum | toString) }}{{- end }}
 {{- $tcpMap := dict }}
+{{- $portOwner := dict }}
 {{- range $t := $allowedTcp }}
 {{- if not (and (ne $smtpPort "") (eq ($t.port | toString) $smtpPort) (ne $t.host $smtpHost)) }}
+{{- $pk := ($t.port | toString) }}
+{{- if and (hasKey $portOwner $pk) (ne (get $portOwner $pk) $t.host) }}
+{{- fail (printf "ingress.istio.egress.allowedTcp: más de un host en el puerto %s (%s y %s). Istio no distingue ServiceEntry TCP sin addresses en un mismo puerto: usá un único host por puerto." $pk (get $portOwner $pk) $t.host) }}
+{{- end }}
+{{- $_ := set $portOwner $pk $t.host }}
 {{- $_ := set $tcpMap (printf "%s:%v" $t.host $t.port) $t }}
 {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -8,6 +8,11 @@
 {{- range (splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22")) -}}
 {{- $exclPorts = append $exclPorts (trim .) -}}
 {{- end -}}
+{{- /* 443 NO puede excluirse: el HTTPS debe pasar por el sidecar (REGISTRY_ONLY) para que aplique
+   el allowlist. Si se excluye, saldría directo (la NP deja salir 443 a cualquier IP) sin control. */ -}}
+{{- if has "443" $exclPorts -}}
+{{- fail "ingress.istio.egress.excludeOutboundPorts no puede incluir 443: el HTTPS debe pasar por el sidecar para que aplique la whitelist. Quitá 443 de la lista." -}}
+{{- end -}}
 {{- $smtpPorts := without $exclPorts "22" -}}
 {{- $smtpCidrs := ($egress.outboundTcpCidrs | default list) -}}
 {{- $sshOn := and ($egress.repoSsh) .Values.adhoc.devMode (has "22" $exclPorts) -}}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -73,7 +73,9 @@ spec:
   policyTypes:
   - Egress
   egress:
-  # Privado / in-cluster / istiod / DNS (cualquier puerto).
+  # Privado / in-cluster / istiod / DNS (cualquier puerto). RFC1918 + link-local cubren kube-dns,
+  # NodeLocal, istiod y los ClusterIP de servicios. NO se suma networkPolicy.allow acá: ese value
+  # es para pods NO-meshed y podría contener rangos públicos → abriría los puertos excluidos.
   - to:
     - ipBlock:
         cidr: 10.0.0.0/8
@@ -83,10 +85,6 @@ spec:
         cidr: 192.168.0.0/16
     - ipBlock:
         cidr: 169.254.0.0/16
-    {{- range $extra }}
-    - ipBlock:
-        cidr: {{ . | quote }}
-    {{- end }}
   # HTTPS público (443): deja salir al sidecar; REGISTRY_ONLY + ServiceEntries restringen los hosts.
   - to:
     - ipBlock:

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -70,6 +70,9 @@ spec:
     matchLabels:
       {{- include "adhoc-odoo.selectorLabels" . | nindent 6 }}
       adhoc.ar/app-name: "odoo"
+      # Solo pods realmente inyectados: si la inyección falla, el pod NO matchea acá y queda solo
+      # con la NP no-meshed (deny público). Sin esto, un pod sin sidecar tendría 443 abierto.
+      security.istio.io/tlsMode: istio
   policyTypes:
   - Egress
   egress:

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -9,7 +9,8 @@
 {{- $exclRaw := (index (.Values.podAnnotations | default dict) "traffic.sidecar.istio.io/excludeOutboundPorts") | default (($egress.excludeOutboundPorts) | default "587,465,25,22") -}}
 {{- $exclPorts := list -}}
 {{- range (splitList "," $exclRaw) -}}
-{{- $exclPorts = append $exclPorts (trim .) -}}
+{{- $p := trim . -}}
+{{- if $p -}}{{- $exclPorts = append $exclPorts $p -}}{{- end -}}
 {{- end -}}
 {{- /* 443 NO puede excluirse: el HTTPS debe pasar por el sidecar (REGISTRY_ONLY) para que aplique
    el allowlist. Si se excluye, saldría directo (la NP deja salir 443 a cualquier IP) sin control. */ -}}
@@ -27,7 +28,8 @@
    por alto pero el YAML igual lo parsearía como 465/443). */ -}}
 {{- $openTcpPorts := list -}}
 {{- range ($egress.openTcpPorts | default list) -}}
-{{- $openTcpPorts = append $openTcpPorts (. | toString | trim) -}}
+{{- $p := (. | toString | trim) -}}
+{{- if $p -}}{{- $openTcpPorts = append $openTcpPorts $p -}}{{- end -}}
 {{- end -}}
 {{- /* Un puerto no puede estar en openTcpPorts Y en excludeOutboundPorts: el exclude lo bypassa
    (sin sidecar → sin log ni ServiceEntry), contradiciendo el "abierto + logueado" de openTcpPorts. */ -}}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -24,6 +24,13 @@
 {{- /* openTcpPorts: van por el sidecar (ServiceEntry wildcard en blockOutboundTraffic.yaml), pero
    la NP también tiene que dejarlos salir a 0.0.0.0/0 o Kubernetes los bloquea. */ -}}
 {{- $openTcpPorts := ($egress.openTcpPorts | default list) -}}
+{{- /* Un puerto no puede estar en openTcpPorts Y en excludeOutboundPorts: el exclude lo bypassa
+   (sin sidecar → sin log ni ServiceEntry), contradiciendo el "abierto + logueado" de openTcpPorts. */ -}}
+{{- range $op := $openTcpPorts -}}
+{{- if has ($op | toString) $exclPorts -}}
+{{- fail (printf "El puerto %v está en openTcpPorts Y en excludeOutboundPorts: elegí uno (openTcpPorts pasa por el sidecar y se loguea; excludeOutboundPorts lo bypassa). Sacalo de una de las dos listas." $op) -}}
+{{- end -}}
+{{- end -}}
 # NetworkPolicy de egress (enforce): cubre los pods NO inyectados (PostgreSQL/CNPG, jobs),
 # que sin sidecar saldrían directo por el NAT. Permite solo privado (RFC1918 + link-local) y
 # deniega el público. Los pods meshed (Odoo) los maneja el sidecar + la NP meshed de abajo.

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -1,6 +1,7 @@
 {{- $mode := include "adhoc-odoo.egressMode" . -}}
 {{- if and .Values.ingress.istio.enabled (eq $mode "enforce") -}}
-{{- $extra := (((.Values.ingress.istio.egress | default dict).networkPolicy | default dict).allow | default list) -}}
+{{- $egress := (.Values.ingress.istio.egress | default dict) -}}
+{{- $extra := (($egress.networkPolicy | default dict).allow | default list) -}}
 # NetworkPolicy de egress (enforce): cubre los pods NO inyectados (PostgreSQL/CNPG, jobs),
 # que sin sidecar saldrían directo por el NAT. Permite solo privado (RFC1918 + link-local) y
 # deniega el público. Los pods meshed (Odoo) los maneja el sidecar. Ver doc/adhoc-odoo.md.
@@ -33,4 +34,59 @@ spec:
     - ipBlock:
         cidr: {{ . | quote }}
     {{- end }}
+---
+{{- /* NetworkPolicy del pod MESHED de Odoo. Los puertos server-first (SMTP/SSH) se sacan del
+   sidecar con excludeOutboundPorts (ver deployment.yaml) y salen directo: esta NP es la que los
+   gobierna. Reglas: privado (cualquier puerto: DNS, cluster, istiod) + HTTPS público en 443 (el
+   sidecar REGISTRY_ONLY restringe QUÉ hosts; la NP solo deja salir 443) + los CIDR de relays SMTP
+   / GitHub SSH declarados, en los puertos excluidos. Ver doc/adhoc-odoo.md -> "Egress control". */}}
+{{- $exclPorts := splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22") -}}
+{{- $tcpCidrs := ($egress.outboundTcpCidrs | default list) -}}
+{{- if and ($egress.repoSsh) .Values.adhoc.devMode -}}
+{{- /* GitHub SSH (rangos publicados en https://api.github.com/meta -> "git") */ -}}
+{{- $tcpCidrs = (concat $tcpCidrs (list "140.82.112.0/20" "143.55.64.0/20" "192.30.252.0/22") | uniq) -}}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "adhoc-odoo.fullname" . }}-egress-meshed
+  labels:
+    {{- include "adhoc-odoo.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      adhoc.ar/app-name: "odoo"
+  policyTypes:
+  - Egress
+  egress:
+  # Privado / in-cluster / istiod / DNS (cualquier puerto).
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/8
+    - ipBlock:
+        cidr: 172.16.0.0/12
+    - ipBlock:
+        cidr: 192.168.0.0/16
+    - ipBlock:
+        cidr: 169.254.0.0/16
+  # HTTPS público (443): deja salir al sidecar; REGISTRY_ONLY + ServiceEntries restringen los hosts.
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 443
+  {{- if $tcpCidrs }}
+  # Puertos sacados del sidecar (SMTP/SSH): solo a los CIDR de relays / GitHub declarados.
+  - to:
+    {{- range $tcpCidrs }}
+    - ipBlock:
+        cidr: {{ . | quote }}
+    {{- end }}
+    ports:
+    {{- range $exclPorts }}
+    - protocol: TCP
+      port: {{ . | trim | int }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -2,8 +2,12 @@
 {{- if and .Values.ingress.istio.enabled (eq $mode "enforce") -}}
 {{- $egress := (.Values.ingress.istio.egress | default dict) -}}
 {{- $extra := (($egress.networkPolicy | default dict).allow | default list) -}}
-{{- $exclPorts := splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22") -}}
-{{- /* Reglas separadas por puerto (no cartesiano): relays SMTP en sus puertos, GitHub SSH en 22. */ -}}
+{{- /* Reglas separadas por puerto (no cartesiano): relays SMTP en sus puertos, GitHub SSH en 22.
+   Trim de cada puerto: tolera "587, 465, ..." con espacios (si no, without/has fallarían). */ -}}
+{{- $exclPorts := list -}}
+{{- range (splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22")) -}}
+{{- $exclPorts = append $exclPorts (trim .) -}}
+{{- end -}}
 {{- $smtpPorts := without $exclPorts "22" -}}
 {{- $smtpCidrs := ($egress.outboundTcpCidrs | default list) -}}
 {{- $sshOn := and ($egress.repoSsh) .Values.adhoc.devMode (has "22" $exclPorts) -}}
@@ -70,6 +74,10 @@ spec:
         cidr: 192.168.0.0/16
     - ipBlock:
         cidr: 169.254.0.0/16
+    {{- range $extra }}
+    - ipBlock:
+        cidr: {{ . | quote }}
+    {{- end }}
   # HTTPS público (443): deja salir al sidecar; REGISTRY_ONLY + ServiceEntries restringen los hosts.
   - to:
     - ipBlock:

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -4,8 +4,11 @@
 {{- $extra := (($egress.networkPolicy | default dict).allow | default list) -}}
 {{- /* Reglas separadas por puerto (no cartesiano): relays SMTP en sus puertos, GitHub SSH en 22.
    Trim de cada puerto: tolera "587, 465, ..." con espacios (si no, without/has fallarían). */ -}}
+{{- /* Puertos excluidos EFECTIVOS: el override del usuario en podAnnotations gana (deployment.yaml
+   lo respeta), si no el valor de egress.excludeOutboundPorts. Así la NP no diverge del pod. */ -}}
+{{- $exclRaw := (index (.Values.podAnnotations | default dict) "traffic.sidecar.istio.io/excludeOutboundPorts") | default (($egress.excludeOutboundPorts) | default "587,465,25,22") -}}
 {{- $exclPorts := list -}}
-{{- range (splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22")) -}}
+{{- range (splitList "," $exclRaw) -}}
 {{- $exclPorts = append $exclPorts (trim .) -}}
 {{- end -}}
 {{- /* 443 NO puede excluirse: el HTTPS debe pasar por el sidecar (REGISTRY_ONLY) para que aplique
@@ -65,6 +68,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
+      {{- include "adhoc-odoo.selectorLabels" . | nindent 6 }}
       adhoc.ar/app-name: "odoo"
   policyTypes:
   - Egress

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -41,11 +41,12 @@ spec:
    sidecar REGISTRY_ONLY restringe QUÉ hosts; la NP solo deja salir 443) + los CIDR de relays SMTP
    / GitHub SSH declarados, en los puertos excluidos. Ver doc/adhoc-odoo.md -> "Egress control". */}}
 {{- $exclPorts := splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22") -}}
-{{- $tcpCidrs := ($egress.outboundTcpCidrs | default list) -}}
-{{- if and ($egress.repoSsh) .Values.adhoc.devMode -}}
-{{- /* GitHub SSH (rangos publicados en https://api.github.com/meta -> "git") */ -}}
-{{- $tcpCidrs = (concat $tcpCidrs (list "140.82.112.0/20" "143.55.64.0/20" "192.30.252.0/22") | uniq) -}}
-{{- end }}
+{{- /* Reglas separadas por puerto (no cartesiano): relays SMTP en sus puertos, GitHub SSH en 22. */ -}}
+{{- $smtpPorts := without $exclPorts "22" -}}
+{{- $smtpCidrs := ($egress.outboundTcpCidrs | default list) -}}
+{{- $sshOn := and ($egress.repoSsh) .Values.adhoc.devMode (has "22" $exclPorts) -}}
+{{- /* GitHub: rangos git de https://api.github.com/meta ("git"). Override/sync vía egress.repoSshCidrs. */ -}}
+{{- $sshCidrs := ($egress.repoSshCidrs | default (list "140.82.112.0/20" "143.55.64.0/20" "185.199.108.0/22" "192.30.252.0/22")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -76,17 +77,28 @@ spec:
     ports:
     - protocol: TCP
       port: 443
-  {{- if $tcpCidrs }}
-  # Puertos sacados del sidecar (SMTP/SSH): solo a los CIDR de relays / GitHub declarados.
+  {{- if and $smtpCidrs $smtpPorts }}
+  # Relays SMTP (y otros TCP no-443) sacados del sidecar: solo a esos CIDR, en sus puertos (no en 22).
   - to:
-    {{- range $tcpCidrs }}
+    {{- range $smtpCidrs }}
     - ipBlock:
         cidr: {{ . | quote }}
     {{- end }}
     ports:
-    {{- range $exclPorts }}
+    {{- range $smtpPorts }}
     - protocol: TCP
       port: {{ . | trim | int }}
     {{- end }}
+  {{- end }}
+  {{- if $sshOn }}
+  # Git por SSH (solo con adhoc.devMode): CIDRs de GitHub únicamente en el puerto 22.
+  - to:
+    {{- range $sshCidrs }}
+    - ipBlock:
+        cidr: {{ . | quote }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 22
   {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -21,6 +21,9 @@
 {{- $sshOn := and ($egress.repoSsh) .Values.adhoc.devMode (has "22" $exclPorts) -}}
 {{- /* GitHub: rangos git de https://api.github.com/meta ("git"). Override/sync vía egress.repoSshCidrs. */ -}}
 {{- $sshCidrs := ($egress.repoSshCidrs | default (list "140.82.112.0/20" "143.55.64.0/20" "185.199.108.0/22" "192.30.252.0/22")) -}}
+{{- /* openTcpPorts: van por el sidecar (ServiceEntry wildcard en blockOutboundTraffic.yaml), pero
+   la NP también tiene que dejarlos salir a 0.0.0.0/0 o Kubernetes los bloquea. */ -}}
+{{- $openTcpPorts := ($egress.openTcpPorts | default list) -}}
 # NetworkPolicy de egress (enforce): cubre los pods NO inyectados (PostgreSQL/CNPG, jobs),
 # que sin sidecar saldrían directo por el NAT. Permite solo privado (RFC1918 + link-local) y
 # deniega el público. Los pods meshed (Odoo) los maneja el sidecar + la NP meshed de abajo.
@@ -95,6 +98,18 @@ spec:
     ports:
     - protocol: TCP
       port: 443
+  {{- if $openTcpPorts }}
+  # openTcpPorts: los mismos puertos que abre el ServiceEntry wildcard, a cualquier IP (van por el
+  # sidecar, logueados). Sin esta regla la NP los bloquearía.
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    {{- range $openTcpPorts }}
+    - protocol: TCP
+      port: {{ . | int }}
+    {{- end }}
+  {{- end }}
   {{- if and $smtpCidrs $smtpPorts }}
   # Relays SMTP (y otros TCP no-443) sacados del sidecar: solo a esos CIDR, en sus puertos (no en 22).
   - to:

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -23,11 +23,16 @@
 {{- $sshCidrs := ($egress.repoSshCidrs | default (list "140.82.112.0/20" "143.55.64.0/20" "185.199.108.0/22" "192.30.252.0/22")) -}}
 {{- /* openTcpPorts: van por el sidecar (ServiceEntry wildcard en blockOutboundTraffic.yaml), pero
    la NP también tiene que dejarlos salir a 0.0.0.0/0 o Kubernetes los bloquea. */ -}}
-{{- $openTcpPorts := ($egress.openTcpPorts | default list) -}}
+{{- /* Trim de cada openTcpPort (tolera "465 " con espacios; si no, los guards de abajo lo pasarían
+   por alto pero el YAML igual lo parsearía como 465/443). */ -}}
+{{- $openTcpPorts := list -}}
+{{- range ($egress.openTcpPorts | default list) -}}
+{{- $openTcpPorts = append $openTcpPorts (. | toString | trim) -}}
+{{- end -}}
 {{- /* Un puerto no puede estar en openTcpPorts Y en excludeOutboundPorts: el exclude lo bypassa
    (sin sidecar → sin log ni ServiceEntry), contradiciendo el "abierto + logueado" de openTcpPorts. */ -}}
 {{- range $op := $openTcpPorts -}}
-{{- if has ($op | toString) $exclPorts -}}
+{{- if has $op $exclPorts -}}
 {{- fail (printf "El puerto %v está en openTcpPorts Y en excludeOutboundPorts: elegí uno (openTcpPorts pasa por el sidecar y se loguea; excludeOutboundPorts lo bypassa). Sacalo de una de las dos listas." $op) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -2,9 +2,16 @@
 {{- if and .Values.ingress.istio.enabled (eq $mode "enforce") -}}
 {{- $egress := (.Values.ingress.istio.egress | default dict) -}}
 {{- $extra := (($egress.networkPolicy | default dict).allow | default list) -}}
+{{- $exclPorts := splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22") -}}
+{{- /* Reglas separadas por puerto (no cartesiano): relays SMTP en sus puertos, GitHub SSH en 22. */ -}}
+{{- $smtpPorts := without $exclPorts "22" -}}
+{{- $smtpCidrs := ($egress.outboundTcpCidrs | default list) -}}
+{{- $sshOn := and ($egress.repoSsh) .Values.adhoc.devMode (has "22" $exclPorts) -}}
+{{- /* GitHub: rangos git de https://api.github.com/meta ("git"). Override/sync vía egress.repoSshCidrs. */ -}}
+{{- $sshCidrs := ($egress.repoSshCidrs | default (list "140.82.112.0/20" "143.55.64.0/20" "185.199.108.0/22" "192.30.252.0/22")) -}}
 # NetworkPolicy de egress (enforce): cubre los pods NO inyectados (PostgreSQL/CNPG, jobs),
 # que sin sidecar saldrían directo por el NAT. Permite solo privado (RFC1918 + link-local) y
-# deniega el público. Los pods meshed (Odoo) los maneja el sidecar. Ver doc/adhoc-odoo.md.
+# deniega el público. Los pods meshed (Odoo) los maneja el sidecar + la NP meshed de abajo.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -35,18 +42,11 @@ spec:
         cidr: {{ . | quote }}
     {{- end }}
 ---
-{{- /* NetworkPolicy del pod MESHED de Odoo. Los puertos server-first (SMTP/SSH) se sacan del
-   sidecar con excludeOutboundPorts (ver deployment.yaml) y salen directo: esta NP es la que los
-   gobierna. Reglas: privado (cualquier puerto: DNS, cluster, istiod) + HTTPS público en 443 (el
-   sidecar REGISTRY_ONLY restringe QUÉ hosts; la NP solo deja salir 443) + los CIDR de relays SMTP
-   / GitHub SSH declarados, en los puertos excluidos. Ver doc/adhoc-odoo.md -> "Egress control". */}}
-{{- $exclPorts := splitList "," (($egress.excludeOutboundPorts) | default "587,465,25,22") -}}
-{{- /* Reglas separadas por puerto (no cartesiano): relays SMTP en sus puertos, GitHub SSH en 22. */ -}}
-{{- $smtpPorts := without $exclPorts "22" -}}
-{{- $smtpCidrs := ($egress.outboundTcpCidrs | default list) -}}
-{{- $sshOn := and ($egress.repoSsh) .Values.adhoc.devMode (has "22" $exclPorts) -}}
-{{- /* GitHub: rangos git de https://api.github.com/meta ("git"). Override/sync vía egress.repoSshCidrs. */ -}}
-{{- $sshCidrs := ($egress.repoSshCidrs | default (list "140.82.112.0/20" "143.55.64.0/20" "185.199.108.0/22" "192.30.252.0/22")) -}}
+# NetworkPolicy del pod MESHED de Odoo. Los puertos server-first (SMTP/SSH) se sacan del sidecar
+# con excludeOutboundPorts (ver deployment.yaml) y salen directo: esta NP es la que los gobierna.
+# Reglas: privado (cualquier puerto: DNS, cluster, istiod) + HTTPS público en 443 (el sidecar
+# REGISTRY_ONLY restringe QUÉ hosts; la NP solo deja salir 443) + relays SMTP / GitHub SSH por
+# CIDR, cada uno en sus puertos. Ver doc/adhoc-odoo.md -> "Egress control".
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-sni-inspector.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-sni-inspector.yaml
@@ -1,14 +1,14 @@
 {{- $mode := include "adhoc-odoo.egressMode" . -}}
 {{- if and .Values.ingress.istio.enabled (or (eq $mode "observe") (eq $mode "enforce")) -}}
 # tls_inspector en virtualOutbound: sin él, el egress TLS en passthrough se loguea como TCP
-# y el `sni` queda vacío. Con él, el access log captura el host externo. Ver doc/adhoc-odoo.md.
+# y el `sni` queda vacío. Con él, el access log captura el host externo (HTTPS/443). Ver doc/adhoc-odoo.md.
 #
-# ACOTADO A 443 (filter_disabled): como INSERT_FIRST, el tls_inspector espera bytes del cliente
-# para detectar TLS/SNI. En protocolos "server-speaks-first" (SMTP 587/465, SSH 22) el servidor
-# habla primero, así que el inspector se cuelga esperando datos que no llegan -> deadlock -> la
-# conexión cae a BlackHole bajo enforce. El SNI solo existe en TLS (443), así que deshabilitamos
-# el filtro fuera de 443: el logging de SNI se conserva y el egress no-443 (SMTP/SSH/allowedTcp)
-# funciona. Sin esto, enforce rompe TODO el egress no-443.
+# IMPORTANTE: como INSERT_FIRST, el inspector espera bytes del cliente para detectar TLS. En
+# protocolos "server-speaks-first" (SMTP 587/STARTTLS, SSH 22) el servidor habla primero → el
+# inspector se cuelga (timeout 15s) → la conexión se resetea (observe) o va a BlackHole (enforce).
+# Por eso esos puertos se sacan del sidecar con `traffic.sidecar.istio.io/excludeOutboundPorts`
+# (ver odoo/deployment.yaml) y se gobiernan por NetworkPolicy, no por Istio. El inspector queda
+# solo para el egress que SÍ pasa por el sidecar (HTTPS/443, donde el cliente manda ClientHello).
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -26,9 +26,4 @@ spec:
           name: envoy.filters.listener.tls_inspector
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-          filter_disabled:
-            not_match:
-              destination_port_range:
-                start: 443
-                end: 444
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-sni-inspector.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-sni-inspector.yaml
@@ -2,6 +2,13 @@
 {{- if and .Values.ingress.istio.enabled (or (eq $mode "observe") (eq $mode "enforce")) -}}
 # tls_inspector en virtualOutbound: sin él, el egress TLS en passthrough se loguea como TCP
 # y el `sni` queda vacío. Con él, el access log captura el host externo. Ver doc/adhoc-odoo.md.
+#
+# ACOTADO A 443 (filter_disabled): como INSERT_FIRST, el tls_inspector espera bytes del cliente
+# para detectar TLS/SNI. En protocolos "server-speaks-first" (SMTP 587/465, SSH 22) el servidor
+# habla primero, así que el inspector se cuelga esperando datos que no llegan -> deadlock -> la
+# conexión cae a BlackHole bajo enforce. El SNI solo existe en TLS (443), así que deshabilitamos
+# el filtro fuera de 443: el logging de SNI se conserva y el egress no-443 (SMTP/SSH/allowedTcp)
+# funciona. Sin esto, enforce rompe TODO el egress no-443.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -19,4 +26,9 @@ spec:
           name: envoy.filters.listener.tls_inspector
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+          filter_disabled:
+            not_match:
+              destination_port_range:
+                start: 443
+                end: 444
 {{- end }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -76,6 +76,17 @@ ingress:
         - "github.com"
         - "codeload.github.com"
         - "objects.githubusercontent.com"
+      # enforce: destinos por IP/CIDR (TLS/443 SIN SNI; match por IP, no por SNI). Se suman al
+      # baseline baked-in (VIP de Private Google Access 199.36.153.8/30, para GCS). Ver
+      # "Egress control" en doc/adhoc-odoo.md. Normalmente vacío.
+      allowedCidrs: []
+      # enforce: destinos TCP host:puerto (SMTP y otros no-443). Default: relays compartidos
+      # conocidos. El relay propio del tenant se deriva de odoo.smtp (no repetir acá).
+      allowedTcp:
+        - {host: "smtp.mailgun.org", port: 587}
+        - {host: "smtp.mailgun.org", port: 465}
+      # enforce: habilita git por SSH (github.com:22). SOLO surte efecto con adhoc.devMode=true.
+      repoSsh: false
     # enforce: hosts externos extra (además de repoHosts). Poblar desde el inventario (observe).
     allowedHosts: []
     logAll: false

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -86,9 +86,16 @@ ingress:
       # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP del tenant, etc.). No se
       # puede derivar de un hostname; usar el rango publicado del proveedor o la IP del relay.
       outboundTcpCidrs: []
-      # enforce: habilita git por SSH agregando los CIDR de GitHub SSH a la NetworkPolicy.
+      # enforce: habilita git por SSH agregando los CIDR de GitHub SSH a la NetworkPolicy (en :22).
       # SOLO surte efecto con adhoc.devMode=true.
       repoSsh: false
+      # CIDRs de GitHub SSH para repoSsh (rangos "git" de https://api.github.com/meta).
+      # Sincronizar si GitHub publica nuevos rangos.
+      repoSshCidrs:
+        - "140.82.112.0/20"
+        - "143.55.64.0/20"
+        - "185.199.108.0/22"
+        - "192.30.252.0/22"
     # enforce: hosts externos extra (además de repoHosts). Poblar desde el inventario (observe).
     allowedHosts: []
     logAll: false

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -79,6 +79,11 @@ ingress:
       # enforce: destinos por IP/CIDR para 443 SIN SNI (match por IP). Se suman al baseline
       # baked-in (VIP de Private Google Access 199.36.153.8/30, para GCS). Normalmente vacío.
       allowedCidrs: []
+      # enforce: puertos "abiertos a priori" — ServiceEntry wildcard que deja salir a CUALQUIER host
+      # en ese puerto, LOGUEADO por el sidecar. SOLO protocolos client-first (el cliente habla
+      # primero: HTTP, PG, Redis, SMTPS-465...). Los server-first (SMTP 587/25/STARTTLS, SSH 22)
+      # NO van acá — cuelgan el tls_inspector; esos van por excludeOutboundPorts. NUNCA poner 80/443.
+      openTcpPorts: []
       # SMTP (587/465/25) y SSH (22) son server-first y cuelgan el tls_inspector del egress: se
       # SACAN del sidecar (estos puertos) y se gobiernan por NetworkPolicy, no por ServiceEntry.
       # Ver "Egress control" en doc/adhoc-odoo.md.

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -76,16 +76,18 @@ ingress:
         - "github.com"
         - "codeload.github.com"
         - "objects.githubusercontent.com"
-      # enforce: destinos por IP/CIDR (TLS/443 SIN SNI; match por IP, no por SNI). Se suman al
-      # baseline baked-in (VIP de Private Google Access 199.36.153.8/30, para GCS). Ver
-      # "Egress control" en doc/adhoc-odoo.md. Normalmente vacío.
+      # enforce: destinos por IP/CIDR para 443 SIN SNI (match por IP). Se suman al baseline
+      # baked-in (VIP de Private Google Access 199.36.153.8/30, para GCS). Normalmente vacío.
       allowedCidrs: []
-      # enforce: destinos TCP host:puerto (SMTP y otros no-443). Default: relays compartidos
-      # conocidos. El relay propio del tenant se deriva de odoo.smtp (no repetir acá).
-      allowedTcp:
-        - {host: "smtp.mailgun.org", port: 587}
-        - {host: "smtp.mailgun.org", port: 465}
-      # enforce: habilita git por SSH (github.com:22). SOLO surte efecto con adhoc.devMode=true.
+      # SMTP (587/465/25) y SSH (22) son server-first y cuelgan el tls_inspector del egress: se
+      # SACAN del sidecar (estos puertos) y se gobiernan por NetworkPolicy, no por ServiceEntry.
+      # Ver "Egress control" en doc/adhoc-odoo.md.
+      excludeOutboundPorts: "587,465,25,22"
+      # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP del tenant, etc.). No se
+      # puede derivar de un hostname; usar el rango publicado del proveedor o la IP del relay.
+      outboundTcpCidrs: []
+      # enforce: habilita git por SSH agregando los CIDR de GitHub SSH a la NetworkPolicy.
+      # SOLO surte efecto con adhoc.devMode=true.
       repoSsh: false
     # enforce: hosts externos extra (además de repoHosts). Poblar desde el inventario (observe).
     allowedHosts: []

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -79,10 +79,11 @@ ingress:
       # enforce: destinos por IP/CIDR para 443 SIN SNI (match por IP). Se suman al baseline
       # baked-in (VIP de Private Google Access 199.36.153.8/30, para GCS). Normalmente vacío.
       allowedCidrs: []
-      # enforce: puertos "abiertos a priori" — ServiceEntry wildcard que deja salir a CUALQUIER host
-      # en ese puerto, LOGUEADO por el sidecar. SOLO protocolos client-first (el cliente habla
-      # primero: HTTP, PG, Redis, SMTPS-465...). Los server-first (SMTP 587/25/STARTTLS, SSH 22)
-      # NO van acá — cuelgan el tls_inspector; esos van por excludeOutboundPorts. NUNCA poner 80/443.
+      # enforce: puertos "abiertos a priori" para egress EXTERNO — ServiceEntry wildcard que deja
+      # salir a CUALQUIER host en ese puerto, LOGUEADO por el sidecar. SOLO protocolos client-first
+      # (el cliente habla primero: HTTPS-alt, SMTPS-465, PG/Redis externos...). Los server-first
+      # (SMTP 587/25/STARTTLS, SSH 22) NO van acá — cuelgan el tls_inspector; esos van por
+      # excludeOutboundPorts. NUNCA poner 80/443 (rechazado). Evitar puertos de servicios in-cluster.
       openTcpPorts: []
       # SMTP (587/465/25) y SSH (22) son server-first y cuelgan el tls_inspector del egress: se
       # SACAN del sidecar (estos puertos) y se gobiernan por NetworkPolicy, no por ServiceEntry.

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -66,6 +66,8 @@ ingress:
         - objects.githubusercontent.com
       allowedCidrs: []          # enforce: destinos por IP/CIDR (443 SIN SNI; match por IP).
                                 #   Baseline baked-in: VIP de Private Google Access (GCS)
+      openTcpPorts: []          # enforce: puertos "abiertos a priori" a CUALQUIER host, LOGUEADOS
+                                #   (client-first: HTTP/PG/Redis/465...). NO server-first, NO 80/443
       # SMTP/SSH (server-first) se sacan del sidecar y se gobiernan por NetworkPolicy (no ServiceEntry):
       excludeOutboundPorts: "587,465,25,22"  # puertos que bypassan el sidecar
       outboundTcpCidrs: []      # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP)
@@ -122,6 +124,11 @@ Notas:
 - **allowedCidrs** matchea por IP destino (no por SNI) → es el camino para el egress a 443 **sin
   SNI** (p.ej. GCS). Baseline baked-in: el `/30` del **Private Google Access** de Google. Requiere
   que la infra rutee `*.googleapis.com` al VIP privado (ver doc de egress en devops-cloud-infra).
+- **openTcpPorts** — puertos "abiertos a priori": emite un ServiceEntry por puerto (`addresses:
+  0.0.0.0/0`) que deja salir a **cualquier host** en ese puerto **y lo loguea** (pasa por el
+  sidecar). Solo para protocolos **client-first** (HTTP, PostgreSQL, Redis, SMTPS-465…); los
+  **server-first** (SMTP 587/25 STARTTLS, SSH 22) cuelgan el `tls_inspector` → esos van por
+  `excludeOutboundPorts`. El chart **rechaza 80/443** acá (romperían el bloqueo/whitelist).
 
 Diseño y rationale completos: specs de egress (firewall + listas blancas enriquecidas) en
 devops-project. Infraestructura del cluster que lo sostiene (NodeLocal DNS, istiod,

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -64,6 +64,12 @@ ingress:
         - github.com            #   se suman a la whitelist solo si odoo.entrypoint.repos != ""
         - codeload.github.com
         - objects.githubusercontent.com
+      allowedCidrs: []          # enforce: destinos por IP/CIDR (443 SIN SNI; match por IP).
+                                #   Baseline baked-in: VIP de Private Google Access (GCS)
+      allowedTcp:               # enforce: destinos TCP host:puerto (SMTP y otros no-443);
+        - {host: "smtp.mailgun.org", port: 587}     #   default: relays compartidos conocidos.
+        - {host: "smtp.mailgun.org", port: 465}     #   El relay del tenant sale de odoo.smtp
+      repoSsh: false            # enforce: git por SSH (github:22) SOLO si adhoc.devMode=true
     logAll: false
     http10:
       enabled: false            # habilitar para HTTP/1.0 legacy
@@ -80,18 +86,35 @@ Postura de salida por tenant vía `ingress.istio.egress.mode` (solo con istio ha
 | --- | --- | --- | --- |
 | `open` | `ALLOW_ANY` | no | no |
 | `observe` (default con istio) | `ALLOW_ANY` | sí (SNI → Cloud Logging) | no |
-| `enforce` | `REGISTRY_ONLY` | sí (hereda observe) | solo `allowedHosts`+`repoHosts`/443; no-TLS y pods no-meshed bloqueados |
+| `enforce` | `REGISTRY_ONLY` | sí (hereda observe) | solo la whitelist (ver matchers); no-TLS, HTTP/80 y pods no-meshed bloqueados |
 
-- **enforce** bloquea en dos capas: el sidecar (`REGISTRY_ONLY`) limita a Odoo a los hosts con
-  `ServiceEntry` (`allowedHosts` + `repoHosts`), salida directa; una `NetworkPolicy` cubre los
-  pods no-meshed (PG/CNPG, jobs) permitiendo solo privado (RFC1918 + link-local).
-- **repoHosts** se suman a la whitelist solo si `odoo.entrypoint.repos` no está vacío (default
-  github en el template, vale bajo `--reuse-values`; sobreescribible para gitlab/etc.).
-- `allowedHosts` se puebla desde el inventario del modo `observe`.
+- **enforce** bloquea en dos capas: el sidecar (`REGISTRY_ONLY`) limita a Odoo a los destinos
+  con `ServiceEntry` (la whitelist), salida directa; una `NetworkPolicy` cubre los pods
+  no-meshed (PG/CNPG, jobs) permitiendo solo privado (RFC1918 + link-local).
 
-Diseño y rationale completos: spec "firewall de egress" (devops-project). Infraestructura del
-cluster que lo sostiene (NodeLocal DNS, istiod, observabilidad): doc de egress en
-devops-cloud-infra.
+La whitelist soporta cuatro tipos de matcher (todos bajo `ingress.istio.egress`):
+
+| Matcher | Value | ServiceEntry emitido | Para |
+| --- | --- | --- | --- |
+| Host/SNI | `allowedHosts` + `repoHosts` | host, 443/HTTPS, DNS | HTTPS con SNI |
+| IP/CIDR | `allowedCidrs` (+ baseline PGA) | `addresses`, 443/TCP, `resolution: NONE` | 443 **sin SNI** (GCS) |
+| host:puerto TCP | `allowedTcp` `[{host, port}]` | host, puerto/TCP, DNS | SMTP y otros no-443 |
+| SSH git | `repoSsh` (+ `adhoc.devMode`) | `github.com`, 22/TCP | git por SSH (solo dev) |
+
+- **allowedHosts** se puebla desde el inventario del modo `observe`.
+- **repoHosts** se suman solo si `odoo.entrypoint.repos` no está vacío (default github en el
+  template, vale bajo `--reuse-values`; sobreescribible para gitlab/etc.).
+- **allowedCidrs** matchea por IP destino (no por SNI) → es el camino para el egress a 443 **sin
+  SNI** (p.ej. GCS). Baseline baked-in: el `/30` del **Private Google Access** de Google. Requiere
+  que la infra rutee `*.googleapis.com` al VIP privado (ver doc de egress en devops-cloud-infra).
+- **allowedTcp** + el relay propio del tenant (derivado de `odoo.smtp.host:port`) habilitan el
+  **SMTP saliente** (587/465/25). Default: relays compartidos conocidos (Mailgun).
+- **repoSsh** habilita `github.com:22` **solo** con `adhoc.devMode=true`; en prod y tests comunes
+  el git por SSH queda bloqueado.
+
+Diseño y rationale completos: specs de egress (firewall + listas blancas enriquecidas) en
+devops-project. Infraestructura del cluster que lo sostiene (NodeLocal DNS, istiod,
+Private Google Access, observabilidad): doc de egress en devops-cloud-infra.
 
 ### Reverse Proxy (odooEdgeProxy sidecar)
 

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -66,10 +66,10 @@ ingress:
         - objects.githubusercontent.com
       allowedCidrs: []          # enforce: destinos por IP/CIDR (443 SIN SNI; match por IP).
                                 #   Baseline baked-in: VIP de Private Google Access (GCS)
-      allowedTcp:               # enforce: destinos TCP host:puerto (SMTP y otros no-443);
-        - {host: "smtp.mailgun.org", port: 587}     #   default: relays compartidos conocidos.
-        - {host: "smtp.mailgun.org", port: 465}     #   El relay del tenant sale de odoo.smtp
-      repoSsh: false            # enforce: git por SSH (github:22) SOLO si adhoc.devMode=true
+      # SMTP/SSH (server-first) se sacan del sidecar y se gobiernan por NetworkPolicy (no ServiceEntry):
+      excludeOutboundPorts: "587,465,25,22"  # puertos que bypassan el sidecar
+      outboundTcpCidrs: []      # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP)
+      repoSsh: false            # enforce: agrega CIDRs de GitHub SSH a la NP, SOLO si adhoc.devMode
     logAll: false
     http10:
       enabled: false            # habilitar para HTTP/1.0 legacy
@@ -86,20 +86,34 @@ Postura de salida por tenant vía `ingress.istio.egress.mode` (solo con istio ha
 | --- | --- | --- | --- |
 | `open` | `ALLOW_ANY` | no | no |
 | `observe` (default con istio) | `ALLOW_ANY` | sí (SNI → Cloud Logging) | no |
-| `enforce` | `REGISTRY_ONLY` | sí (hereda observe) | solo la whitelist (ver matchers); no-TLS, HTTP/80 y pods no-meshed bloqueados |
+| `enforce` | `REGISTRY_ONLY` | sí (hereda observe) | solo la whitelist (ver abajo); no-TLS, HTTP/80 y pods no-meshed bloqueados |
 
-- **enforce** bloquea en dos capas: el sidecar (`REGISTRY_ONLY`) limita a Odoo a los destinos
-  con `ServiceEntry` (la whitelist), salida directa; una `NetworkPolicy` cubre los pods
-  no-meshed (PG/CNPG, jobs) permitiendo solo privado (RFC1918 + link-local).
+**enforce bloquea en dos planos**, según por dónde sale el tráfico:
 
-La whitelist soporta cuatro tipos de matcher (todos bajo `ingress.istio.egress`):
+1. **Istio (sidecar `REGISTRY_ONLY`)** — el egress HTTPS/443 que pasa por el sidecar: solo los
+   destinos con `ServiceEntry`. Dos tipos de matcher:
 
-| Matcher | Value | ServiceEntry emitido | Para |
-| --- | --- | --- | --- |
-| Host/SNI | `allowedHosts` + `repoHosts` | host, 443/HTTPS, DNS | HTTPS con SNI |
-| IP/CIDR | `allowedCidrs` (+ baseline PGA) | `addresses`, 443/TCP, `resolution: NONE` | 443 **sin SNI** (GCS) |
-| host:puerto TCP | `allowedTcp` `[{host, port}]` | host, puerto/TCP, DNS | SMTP y otros no-443 |
-| SSH git | `repoSsh` (+ `adhoc.devMode`) | `github.com`, 22/TCP | git por SSH (solo dev) |
+   | Matcher | Value | ServiceEntry | Para |
+   | --- | --- | --- | --- |
+   | Host/SNI | `allowedHosts` + `repoHosts` | host, 443/HTTPS, DNS | HTTPS con SNI |
+   | IP/CIDR | `allowedCidrs` (+ baseline PGA) | `addresses`, 443/TCP, `resolution: NONE` | 443 **sin SNI** (GCS) |
+
+2. **NetworkPolicy** — dos políticas: una para los pods **no-meshed** (PG/CNPG, jobs; solo
+   privado) y otra para el pod **meshed de Odoo**. Esta última deja salir privado + HTTPS/443
+   (que el sidecar re-restringe) + los **puertos sacados del sidecar** (`excludeOutboundPorts`)
+   solo a los CIDR declarados.
+
+**SMTP y SSH NO van por ServiceEntry.** Son *server-speaks-first* (el servidor manda el banner
+primero) y cuelgan el `tls_inspector` del egress logging → bajo `REGISTRY_ONLY` irían a BlackHole.
+Por eso esos puertos (`excludeOutboundPorts`, default `587,465,25,22`) se **sacan del sidecar** y
+se allowlistean por **CIDR** en la NetworkPolicy del pod meshed:
+
+- **outboundTcpCidrs** — CIDRs permitidos en esos puertos (rango del relay SMTP del tenant, etc.).
+  No se puede derivar de un hostname: usar el rango publicado del proveedor o la IP del relay.
+- **repoSsh** (+ `adhoc.devMode`) — agrega los CIDR de GitHub SSH (`140.82.112.0/20`, etc.) a la
+  NetworkPolicy; en prod y tests comunes el git por SSH queda bloqueado.
+
+Notas:
 
 - **allowedHosts** se puebla desde el inventario del modo `observe`.
 - **repoHosts** se suman solo si `odoo.entrypoint.repos` no está vacío (default github en el
@@ -107,10 +121,6 @@ La whitelist soporta cuatro tipos de matcher (todos bajo `ingress.istio.egress`)
 - **allowedCidrs** matchea por IP destino (no por SNI) → es el camino para el egress a 443 **sin
   SNI** (p.ej. GCS). Baseline baked-in: el `/30` del **Private Google Access** de Google. Requiere
   que la infra rutee `*.googleapis.com` al VIP privado (ver doc de egress en devops-cloud-infra).
-- **allowedTcp** + el relay propio del tenant (derivado de `odoo.smtp.host:port`) habilitan el
-  **SMTP saliente** (587/465/25). Default: relays compartidos conocidos (Mailgun).
-- **repoSsh** habilita `github.com:22` **solo** con `adhoc.devMode=true`; en prod y tests comunes
-  el git por SSH queda bloqueado.
 
 Diseño y rationale completos: specs de egress (firewall + listas blancas enriquecidas) en
 devops-project. Infraestructura del cluster que lo sostiene (NodeLocal DNS, istiod,

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -108,10 +108,11 @@ primero) y cuelgan el `tls_inspector` del egress logging → bajo `REGISTRY_ONLY
 Por eso esos puertos (`excludeOutboundPorts`, default `587,465,25,22`) se **sacan del sidecar** y
 se allowlistean por **CIDR** en la NetworkPolicy del pod meshed:
 
-- **outboundTcpCidrs** — CIDRs permitidos en esos puertos (rango del relay SMTP del tenant, etc.).
-  No se puede derivar de un hostname: usar el rango publicado del proveedor o la IP del relay.
-- **repoSsh** (+ `adhoc.devMode`) — agrega los CIDR de GitHub SSH (`140.82.112.0/20`, etc.) a la
-  NetworkPolicy; en prod y tests comunes el git por SSH queda bloqueado.
+- **outboundTcpCidrs** — CIDRs permitidos en los puertos SMTP (los excluidos **salvo 22**). No se
+  puede derivar de un hostname: usar el rango publicado del proveedor o la IP del relay.
+- **repoSsh** (+ `adhoc.devMode`) — agrega los CIDR de GitHub (`repoSshCidrs`, rangos "git" de
+  `api.github.com/meta`) a la NetworkPolicy **solo en el puerto 22**; en prod y tests comunes el
+  git por SSH queda bloqueado. Las reglas SMTP y SSH son **por puerto** (no se mezclan).
 
 Notas:
 


### PR DESCRIPTION
## Qué

Iteración 3 del firewall de egress (devops-project #70061, paraguas #70060). Bajo `enforce`
(`REGISTRY_ONLY`) la whitelist asumía que **todo el egress es HTTPS/443 con SNI** y rompía egress
legítimo (validado en `observe` en cell01). Se enriquece la whitelist de `adhoc-odoo` con cuatro
tipos de matcher, bajo `ingress.istio.egress`:

| Matcher | Value | ServiceEntry | Cubre |
| --- | --- | --- | --- |
| Host/SNI (ya existía) | `allowedHosts` + `repoHosts` | host, 443/HTTPS, DNS | HTTPS con SNI |
| **IP/CIDR** | `allowedCidrs` (+ baseline PGA) | `addresses`, 443/TCP, `resolution: NONE` | 443 **sin SNI** (GCS) |
| **host:puerto TCP** | `allowedTcp` `[{host,port}]` | host, puerto/TCP, DNS | SMTP y otros no-443 |
| **SSH git** | `repoSsh` (+ `adhoc.devMode`) | `github.com`, 22/TCP | git por SSH (solo dev) |

- **CIDR por `resolution: NONE`/TCP** → match por IP destino, sin inspección de SNI: resuelve el
  egress a Google sin `server_name`. Baseline baked-in: `199.36.153.8/30` (VIP de Private Google
  Access). **Prerequisito de infra:** habilitar PGA + rutear `*.googleapis.com` al VIP (hoy el
  cluster pega a IPs públicas de Google) — tarea en devops-cloud-infra.
- **SMTP** sale de `odoo.smtp.host:port` (configurable por tenant) + lista default de relays
  conocidos (Mailgun). Puerto 25 soportado por el mismo mecanismo.
- **SSH** (`github.com:22`) solo con `adhoc.devMode=true`; bloqueado en prod y tests comunes.

## Compatibilidad

**Aditivo y opt-in. Sin bump de chart.** Sin los values nuevos, el comportamiento es el de la
it.2. Los defaults están baked-in en el template (no solo en `values.yaml`) para que apliquen bajo
`helm upgrade --reuse-values`.

## Validación

`helm lint` + `helm template` (11 ServiceEntries en el caso full): enforce defaults (CIDR /30 +
Mailgun TCP), SMTP derivado de `odoo.smtp`, SSH solo con devMode (gating verificado), override de
`allowedCidrs`, `observe`→0 recursos, y worst-case `--reuse-values` (`egress=null` + flag legacy)
sin nil-crash. La validación semántica en un tenant de test queda para después de habilitar PGA.

## Specs / docs

- Spec it.3: `devops-project/specs/10_draft/egress-allowlist-enriquecida.md` (#70061).
- Config del chart: `doc/adhoc-odoo.md` → "Egress control".
- Infra (PGA, observabilidad): `devops-cloud-infra/doc/egress.md`.