### PR TITLE
fix: egress NetworkPolicy usa namespaceSelector para in-cluster (Cilium/Dataplane V2)

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -57,7 +57,11 @@ spec:
   - Egress
   egress:
   - to:
-    # Privado / in-cluster / infra (todo lo no-público). El resto (Internet) queda denegado.
+    # In-cluster por identidad (namespaceSelector) + privado/host por CIDR. En Cilium/Dataplane V2
+    # el ipBlock CIDR no habilita el egress a pods del cluster (peers CNPG, kube-dns backends): eso
+    # lo cubre namespaceSelector:{}. Los ipBlock privados cubren destinos privados NO-cluster y el
+    # link-local (NodeLocal DNSCache + metadata). El resto (Internet) queda denegado.
+    - namespaceSelector: {}
     - ipBlock:
         cidr: 10.0.0.0/8
     - ipBlock:
@@ -93,10 +97,17 @@ spec:
   policyTypes:
   - Egress
   egress:
-  # Privado / in-cluster / istiod / DNS (cualquier puerto). RFC1918 + link-local cubren kube-dns,
-  # NodeLocal, istiod y los ClusterIP de servicios. NO se suma networkPolicy.allow acá: ese value
-  # es para pods NO-meshed y podría contener rangos públicos → abriría los puertos excluidos.
+  # In-cluster por IDENTIDAD (namespaceSelector) + privado/host por CIDR.
+  # CLAVE en GKE Dataplane V2 (Cilium/anetd): un `ipBlock` CIDR NO habilita el egress a pods del
+  # cluster — Cilium los matchea por identidad, no por CIDR. Sin `namespaceSelector` el sidecar no
+  # puede llegar a istiod (15012) y el pod NO ARRANCA bajo enforce (istio-proxy nunca queda ready).
+  # Por eso namespaceSelector:{} cubre istiod, kube-dns backends, la DB CNPG y demás pods del cluster.
+  # Los ipBlock privados quedan para destinos privados NO-cluster (Cloud SQL, LBs internos) y el
+  # link-local (169.254/16) para NodeLocal DNSCache (169.254.20.10) y el metadata server
+  # (169.254.169.254). NO se suma networkPolicy.allow acá: ese value es para pods NO-meshed y podría
+  # contener rangos públicos → abriría los puertos excluidos.
   - to:
+    - namespaceSelector: {}
     - ipBlock:
         cidr: 10.0.0.0/8
     - ipBlock:

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -105,6 +105,13 @@ Postura de salida por tenant vía `ingress.istio.egress.mode` (solo con istio ha
    (que el sidecar re-restringe) + los **puertos sacados del sidecar** (`excludeOutboundPorts`)
    solo a los CIDR declarados.
 
+   > **In-cluster por identidad (Cilium / GKE Dataplane V2).** Ambas políticas usan
+   > `namespaceSelector: {}` para el egress in-cluster. En Dataplane V2 (anetd/Cilium) un `ipBlock`
+   > CIDR **no** habilita el tráfico a pods del cluster (Cilium los matchea por identidad, no por
+   > CIDR): sin `namespaceSelector` el sidecar no llega a **istiod** y el pod **no arranca** bajo
+   > `enforce`. Los `ipBlock` privados quedan para destinos privados **no-cluster** (Cloud SQL, LBs
+   > internos) y el link-local `169.254.0.0/16` cubre NodeLocal DNSCache y el metadata server.
+
 **SMTP y SSH NO van por ServiceEntry.** Son *server-speaks-first* (el servidor manda el banner
 primero) y cuelgan el `tls_inspector` del egress logging → bajo `REGISTRY_ONLY` irían a BlackHole.
 Por eso esos puertos (`excludeOutboundPorts`, default `587,465,25,22`) se **sacan del sidecar** y


### PR DESCRIPTION
## Problema (crítico para `enforce`)

En GKE **Dataplane V2** (anetd/Cilium) — los clusters nuevos (`cluster01`/`cluster02`) — un `ipBlock` CIDR **no** habilita el egress a pods del cluster: Cilium los matchea por **identidad**, no por CIDR. La NetworkPolicy de egress (it.2 #85 / it.3 #86) solo permitía in-cluster por `ipBlock: 10.0.0.0/8` (+ RFC1918), así que bajo `enforce`:

- El **sidecar no llega a istiod** (`10.x:15012`) → `istio-proxy` nunca queda *ready* → **el pod de Odoo NO arranca**.
- Por transitividad quedaban en riesgo DNS (NodeLocal `169.254.20.10`), la DB CNPG y demás tráfico in-cluster.

Detectado probando SSH+devMode end-to-end sobre un tenant real: al nacer bajo `enforce`, `istio-proxy` loguea `dial tcp <istiod>:15012: i/o timeout` (firma de drop por NetworkPolicy). Borrar la NP meshed → el proxy conecta al instante.

## Fix

Se agrega `namespaceSelector: {}` a la primera regla de **ambas** NetworkPolicies (meshed y no-meshed) → habilita el egress in-cluster por identidad (istiod, kube-dns backends, DB CNPG). Los `ipBlock` privados quedan para destinos privados **no-cluster** (Cloud SQL, LBs internos) y el link-local `169.254.0.0/16` para NodeLocal DNSCache + metadata server.

## Validación (cluster01, probe nacido bajo `enforce` con la NP renderizada por el chart)

| Check | Resultado |
|---|---|
| Bootstrap del sidecar (istiod vía `namespaceSelector`) | ✅ pod 2/2 en ~5s |
| DNS (NodeLocal `169.254.20.10`) | ✅ resuelve |
| Metadata server `169.254.169.254` | ✅ alcanzable |
| `www.google.com:443` (whitelist) | ✅ permitido |
| `example.com:443` (no whitelist) | ✅ BlackHole (reset) |
| `github.com:22` (repoSsh+devMode) | ✅ banner SSH |
| `gitlab.com:22` (no-github) | ✅ bloqueado |

## Compatibilidad

Sin bump del chart (`0.3.4`). Cambia **solo** el path `enforce` (aditivo); `observe`/`open` no emiten NetworkPolicy. Ningún tenant está en `enforce` hoy (default `observe`), así que no afecta deployments vigentes.

Ref: spec it.3 `30_done/0010-egress-allowlist-enriquecida.md` (devops-project), sigue #85/#86.