### PR TITLE
refactor: egress values coherentes (allowedHosts bajo egress, repoSsh default true)

### DIFF
--- a/charts/adhoc-odoo/questions.yml
+++ b/charts/adhoc-odoo/questions.yml
@@ -504,10 +504,17 @@ questions:
       - enforce
     required: false
     default: ""
-  - variable: ingress.istio.allowedHosts
+  - variable: ingress.istio.egress.allowedHosts
     group: "Ingress"
     label: "Allowed Hosts (egress whitelist)"
     description: "enforce: the only external hosts reachable, by SNI (list of strings)."
+    type: "listofstrings"
+    default: []
+    required: false
+  - variable: ingress.istio.egress.allowedCidrs
+    group: "Ingress"
+    label: "Allowed CIDRs (egress, 443 no-SNI)"
+    description: "enforce: extra IP/CIDR destinations for 443 WITHOUT SNI (matched by IP), besides the baked-in Private Google Access VIP (GCS). List of CIDRs."
     type: "listofstrings"
     default: []
     required: false

--- a/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/blockOutboundTraffic.yaml
@@ -12,7 +12,7 @@
 # NetworkPolicy (egress-networkpolicy.yaml). Ver doc/adhoc-odoo.md -> "Egress control".
 #
 # --- 1. Hosts por SNI (HTTPS/443) ---
-{{- $hosts := (.Values.ingress.istio.allowedHosts | default list) }}
+{{- $hosts := ((($egress).allowedHosts) | default list) }}
 {{- if .Values.odoo.entrypoint.repos }}
 {{- /* default github en el template también, para que aplique bajo --reuse-values */}}
 {{- $repoHosts := ((($egress).repoHosts) | default (list "github.com" "codeload.github.com" "objects.githubusercontent.com")) }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -76,6 +76,9 @@ ingress:
         - "github.com"
         - "codeload.github.com"
         - "objects.githubusercontent.com"
+      # enforce: hosts externos extra alcanzables por SNI (443), además de repoHosts. Es la
+      # whitelist principal de egress. Poblar desde el inventario del modo observe.
+      allowedHosts: []
       # enforce: destinos por IP/CIDR para 443 SIN SNI (match por IP). Se suman al baseline
       # baked-in (VIP de Private Google Access 199.36.153.8/30, para GCS). Normalmente vacío.
       allowedCidrs: []
@@ -93,8 +96,9 @@ ingress:
       # puede derivar de un hostname; usar el rango publicado del proveedor o la IP del relay.
       outboundTcpCidrs: []
       # enforce: habilita git por SSH agregando los CIDR de GitHub SSH a la NetworkPolicy (en :22).
-      # SOLO surte efecto con adhoc.devMode=true.
-      repoSsh: false
+      # SOLO surte efecto con adhoc.devMode=true (no-op en prod) → default true: en devMode abre
+      # GitHub:22 automáticamente. Poner false para un dev sin git-SSH.
+      repoSsh: true
       # CIDRs de GitHub SSH para repoSsh (rangos "git" de https://api.github.com/meta).
       # Sincronizar si GitHub publica nuevos rangos.
       repoSshCidrs:
@@ -102,8 +106,6 @@ ingress:
         - "143.55.64.0/20"
         - "185.199.108.0/22"
         - "192.30.252.0/22"
-    # enforce: hosts externos extra (además de repoHosts). Poblar desde el inventario (observe).
-    allowedHosts: []
     logAll: false
     # DEPRECADO: usar egress.mode. Compat: logEgress=true → observe.
     logEgress: false

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -51,7 +51,6 @@ ingress:
     cloudMainDomain: shared.dev-adhoc.com
     altHosts: ""
     createCertificate: true
-    allowedHosts: []            # enforce: hosts externos extra (whitelist), por SNI
     egress:
       mode: ""                  # "" | open | observe | enforce ("" → observe con istio)
       meshExternalNamespaces:   # enforce: ns cluster-level que Odoo usa cross-namespace
@@ -64,6 +63,7 @@ ingress:
         - github.com            #   se suman a la whitelist solo si odoo.entrypoint.repos != ""
         - codeload.github.com
         - objects.githubusercontent.com
+      allowedHosts: []          # enforce: whitelist principal — hosts externos por SNI (443)
       allowedCidrs: []          # enforce: destinos por IP/CIDR (443 SIN SNI; match por IP).
                                 #   Baseline baked-in: VIP de Private Google Access (GCS)
       openTcpPorts: []          # enforce: puertos "abiertos a priori" a CUALQUIER host, LOGUEADOS
@@ -71,7 +71,8 @@ ingress:
       # SMTP/SSH (server-first) se sacan del sidecar y se gobiernan por NetworkPolicy (no ServiceEntry):
       excludeOutboundPorts: "587,465,25,22"  # puertos que bypassan el sidecar
       outboundTcpCidrs: []      # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP)
-      repoSsh: false            # enforce: agrega CIDRs de GitHub SSH a la NP, SOLO si adhoc.devMode
+      repoSsh: true             # enforce: agrega CIDRs de GitHub SSH a la NP, SOLO con adhoc.devMode
+                                #   (no-op en prod). Default true → devMode abre GitHub:22; false para dev sin SSH
     logAll: false
     http10:
       enabled: false            # habilitar para HTTP/1.0 legacy
@@ -112,9 +113,11 @@ se allowlistean por **CIDR** en la NetworkPolicy del pod meshed:
 
 - **outboundTcpCidrs** — CIDRs permitidos en los puertos SMTP (los excluidos **salvo 22**). No se
   puede derivar de un hostname: usar el rango publicado del proveedor o la IP del relay.
-- **repoSsh** (+ `adhoc.devMode`) — agrega los CIDR de GitHub (`repoSshCidrs`, rangos "git" de
-  `api.github.com/meta`) a la NetworkPolicy **solo en el puerto 22**; en prod y tests comunes el
-  git por SSH queda bloqueado. Las reglas SMTP y SSH son **por puerto** (no se mezclan).
+- **repoSsh** (default `true`) — agrega los CIDR de GitHub (`repoSshCidrs`, rangos "git" de
+  `api.github.com/meta`) a la NetworkPolicy **solo en el puerto 22**. **Solo surte efecto con
+  `adhoc.devMode=true`** (es no-op en prod → ahí git-SSH queda bloqueado igual). Con `devMode` abre
+  GitHub:22 por defecto; poner `repoSsh: false` para un dev sin git-SSH. Reglas SMTP y SSH **por
+  puerto** (no se mezclan).
 
 Notas:
 


### PR DESCRIPTION
Limpieza de coherencia sobre la API de values de egress (sigue #85/#86; complementa el fix #87).

## Cambios

1. **`allowedHosts` → `egress.allowedHosts`** *(BREAKING, sin fallback)*. Era el **único** value de egress que quedaba fuera del bloque `ingress.istio.egress.*`, y encima es la whitelist principal (host/SNI en 443). Rename en `values.yaml`, `blockOutboundTraffic.yaml`, `questions.yml` y doc.
2. **`repoSsh` default `false` → `true`**. El gate real es `and repoSsh devMode (has "22")` → **no-op sin `adhoc.devMode`**: en prod no cambia nada (git-SSH sigue bloqueado), en `devMode` abre GitHub:22 por defecto. Opt-out con `repoSsh: false`.
3. **`questions.yml`**: expone `ingress.istio.egress.allowedCidrs` (443 sin SNI por IP/CIDR).
4. **`networkPolicy.allow`**: se mantiene — es el escape hatch de CIDRs extra para pods **no-meshed** (p.ej. CNPG→GCS backup bajo enforce). No está muerto.

## ⚠️ BREAKING

Cualquier generador de values (Tuqui/OWC) que setee `ingress.istio.allowedHosts` debe migrar a `ingress.istio.egress.allowedHosts` — el path viejo se ignora silenciosamente. **Impacto real hoy: nulo** — enforce no está desplegado en ningún tenant y `allowedHosts` está vacío en todos lados (verificado: ningún consumidor en el repo referencia el path viejo). Es el momento óptimo para el rename.

## Verificación

- `helm lint` ✅
- `allowedHosts` vía `egress.allowedHosts` → genera el ServiceEntry ✅
- `repoSsh` default true + `devMode=true` → regla `:22` presente ✅; `devMode=false` (prod) → sin `:22` ✅
- 0 refs residuales a `.Values.ingress.istio.allowedHosts` ✅
- Sin bump (`0.3.4`).

Nota: complementa **#87** (fix NP `namespaceSelector` para Cilium). Ambos tocan `doc/adhoc-odoo.md` en secciones distintas; si #87 mergea primero, rebaso.