### PR TITLE
chore: eliminar flags de egress deprecados (blockOutboundTraffic, logEgress)

### DIFF
--- a/charts/adhoc-odoo/questions.yml
+++ b/charts/adhoc-odoo/questions.yml
@@ -485,13 +485,6 @@ questions:
     type: "string"
     required: false
     default: ""
-  - variable: ingress.istio.blockOutboundTraffic
-    group: "Ingress"
-    label: "Block outbound traffic"
-    description: "Block outbound traffic from Istio Ingress"
-    type: "boolean"
-    required: false
-    default: false
   - variable: ingress.istio.egress.mode
     group: "Ingress"
     label: "Egress mode"

--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -216,8 +216,7 @@ adhoc-odoo.egressMode — resuelve el modo de egress efectivo: open | observe | 
 - open: ALLOW_ANY, sin logging ni bloqueo.
 - observe: ALLOW_ANY + logging de egress (tls_inspector + Telemetry).
 - enforce: REGISTRY_ONLY + listas (allow/ban) + NetworkPolicy. Hereda el logging.
-Precedencia: ingress.istio.egress.mode explícito > flags legacy
-(blockOutboundTraffic→enforce, logEgress→observe) > default "observe" con istio.enabled.
+Fuente única: ingress.istio.egress.mode. Vacío con istio.enabled → default "observe".
 Sin istio.enabled devuelve "open" (los recursos de egress no aplican).
 */}}
 {{- define "adhoc-odoo.egressMode" -}}
@@ -225,13 +224,7 @@ Sin istio.enabled devuelve "open" (los recursos de egress no aplican).
 {{- if not $istio.enabled -}}
 {{- "open" -}}
 {{- else -}}
-{{- $egress := $istio.egress | default dict -}}
-{{- $mode := $egress.mode | default "" -}}
-{{- if not $mode -}}
-  {{- if $istio.blockOutboundTraffic -}}{{- $mode = "enforce" -}}
-  {{- else if $istio.logEgress -}}{{- $mode = "observe" -}}
-  {{- else -}}{{- $mode = "observe" -}}{{- end -}}
-{{- end -}}
+{{- $mode := ($istio.egress | default dict).mode | default "observe" -}}
 {{- if not (has $mode (list "open" "observe" "enforce")) -}}
   {{- fail (printf "ingress.istio.egress.mode inválido: %q (open|observe|enforce)" $mode) -}}
 {{- end -}}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -107,10 +107,6 @@ ingress:
         - "185.199.108.0/22"
         - "192.30.252.0/22"
     logAll: false
-    # DEPRECADO: usar egress.mode. Compat: logEgress=true → observe.
-    logEgress: false
-    # DEPRECADO: usar egress.mode. Compat: blockOutboundTraffic=true → enforce.
-    blockOutboundTraffic: false
     http10:
       enabled: false
 

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -78,8 +78,7 @@ ingress:
       enabled: false            # habilitar para HTTP/1.0 legacy
 ```
 
-`blockOutboundTraffic`/`logEgress` quedan como flags legacy (deprecados): el helper de modo
-los mapea a `enforce`/`observe`. Ver "Egress control" abajo.
+El modo de egress se controla **solo** por `ingress.istio.egress.mode`. Ver "Egress control" abajo.
 
 ### Egress control
 


### PR DESCRIPTION
Limpieza de los dos flags legacy de egress, ya superados por `ingress.istio.egress.mode` (it.2 #85).

## Cambios
- **`_helpers.tpl`** (`adhoc-odoo.egressMode`): lee **solo** `egress.mode` (vacío + `istio.enabled` → default `observe`). Se quitan las ramas legacy `blockOutboundTraffic→enforce` / `logEgress→observe`.
- **`values.yaml`**: se eliminan `logEgress` y `blockOutboundTraffic`.
- **`questions.yml`**: se quita el campo `blockOutboundTraffic` del form OWC (el canónico `egress.mode` ya está expuesto).
- **`doc/adhoc-odoo.md`**: se quita la nota de flags legacy.

## Verificación
- `helm lint` ✅
- `egressMode`: vacío→observe (0 NP), `observe`→0 NP, `enforce`→2 NP, `istio.enabled=false`→open (0 recursos) ✅
- 0 refs a los flags en templates/values/questions (solo prosa histórica en specs/changelog).

## ⚠️ BREAKING (teórico)
Un config de OWC que todavía setee `blockOutboundTraffic`/`logEgress` deja de tener efecto → migrar a `egress.mode`. **Impacto real nulo**: `egress.mode` ya es el canónico y ningún consumidor del repo usa los flags viejos.

Sigue #85/#86/#87/#88.