### PR TITLE
fix: NP no-meshed permite la VIP de Google APIs (GCS) en 443 bajo enforce

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -74,6 +74,19 @@ spec:
     - ipBlock:
         cidr: {{ . | quote }}
     {{- end }}
+  # GCS / Google APIs (443 sin SNI): los pods NO-meshed también salen a la VIP de Private Google
+  # Access. Los jobs con gcsfuse (p.ej. fixdb) y los backups de CNPG montan/leen GCS; sin sidecar,
+  # esta NP es su único control. Sin esta regla, gcsfuse no valida el bucket bajo enforce → el mount
+  # cuelga → CreateContainerError (wedge). Baseline PGA /30 + allowedCidrs, SOLO en 443 (mismo set
+  # que la whitelist IP/CIDR del pod meshed). No abre 0.0.0.0/0: el resto de Internet queda denegado.
+  - to:
+    {{- range (concat (list "199.36.153.8/30") (($egress.allowedCidrs) | default list) | uniq) }}
+    - ipBlock:
+        cidr: {{ . | quote }}
+    {{- end }}
+    ports:
+    - protocol: TCP
+      port: 443
 ---
 # NetworkPolicy del pod MESHED de Odoo. Los puertos server-first (SMTP/SSH) se sacan del sidecar
 # con excludeOutboundPorts (ver deployment.yaml) y salen directo: esta NP es la que los gobierna.

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -101,10 +101,10 @@ Postura de salida por tenant vía `ingress.istio.egress.mode` (solo con istio ha
    | Host/SNI | `allowedHosts` + `repoHosts` | host, 443/HTTPS, DNS | HTTPS con SNI |
    | IP/CIDR | `allowedCidrs` (+ baseline PGA) | `addresses`, 443/TCP, `resolution: NONE` | 443 **sin SNI** (GCS) |
 
-2. **NetworkPolicy** — dos políticas: una para los pods **no-meshed** (PG/CNPG, jobs; solo
-   privado) y otra para el pod **meshed de Odoo**. Esta última deja salir privado + HTTPS/443
-   (que el sidecar re-restringe) + los **puertos sacados del sidecar** (`excludeOutboundPorts`)
-   solo a los CIDR declarados.
+2. **NetworkPolicy** — dos políticas: una para los pods **no-meshed** (PG/CNPG, jobs; privado +
+   la VIP de Google APIs en 443, para gcsfuse/backups a GCS) y otra para el pod **meshed de Odoo**.
+   Esta última deja salir privado + HTTPS/443 (que el sidecar re-restringe) + los **puertos sacados
+   del sidecar** (`excludeOutboundPorts`) solo a los CIDR declarados.
 
    > **In-cluster por identidad (Cilium / GKE Dataplane V2).** Ambas políticas usan
    > `namespaceSelector: {}` para el egress in-cluster. En Dataplane V2 (anetd/Cilium) un `ipBlock`


### PR DESCRIPTION
## Problema (crítico para `enforce`, complementa #87)

Los pods **no-meshed** (jobs con gcsfuse como `fixdb`, backups de CNPG) salen **directo, sin sidecar** → su `NetworkPolicy` es el único control. La NP no-meshed permitía RFC1918 + link-local + in-cluster (`namespaceSelector`), pero **no la VIP de Private Google Access `199.36.153.8/30`**. Bajo `enforce`, gcsfuse no podía validar el bucket:

```
MountVolume.SetUp failed: sidecar bucket access check error:
failed to get GCS bucket "acp-...": Aborted context deadline exceeded
```

→ el mount cuelga → `CreateContainerError` → wedge permanente (reserva stale de containerd).

Diagnóstico en cluster01 sobre un tenant en `enforce`: DNS OK (`storage.googleapis.com → 199.36.153.9`, VIP), pero desde un pod **no-meshed** la VIP `199.36.153.9:443` **timeout**; desde un pod **meshed** (odoo) va **TLS OK** (la NP meshed permite `0.0.0.0/0:443` + la SE `/30`). El gap era solo en la NP no-meshed.

## Dos causas distintas del mismo síntoma (gcsfuse wedge)

| Pod | Causa | Fix |
|---|---|---|
| **meshed** (odoo) | pre-#87: proxy no llegaba a istiod → gcsfuse (arranca tras el proxy) nunca corría | **#87** (namespaceSelector) |
| **no-meshed** (jobs, CNPG) | NP sin la VIP de GCS → gcsfuse no monta | **este PR** |

## Fix

Regla nueva en la NP no-meshed: permite el baseline **PGA `/30` + `allowedCidrs`** SOLO en **443** (mismo set que la whitelist IP/CIDR del pod meshed). **No abre `0.0.0.0/0`** — el resto de Internet sigue denegado para los no-meshed.

## Validación (cluster01, enforce)
- Pod no-meshed con la NP corregida → `storage.googleapis.com:443` **TLS OK** ✅ (antes: timeout)
- `example.com:443` desde no-meshed → **bloqueado** ✅ (enforce se mantiene)
- Pod meshed → GCS TLS OK (ya funcionaba) ✅
- `helm lint` ✅, sin bump.

Sigue #85/#86/#87/#88/#89.