### PR TITLE
feat: sembrar tooling de agentes IA en devMode (completa seed + fix EPERM)

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -106,7 +106,7 @@ spec:
       {{- if .Values.adhoc.devMode }}
       initContainers:
         - name: seed-vscode-server
-          image: adhoc/ops-tools:vscode-sidecar-latest
+          image: {{ .Values.adhoc.sidecarImage | default "adhoc/ops-tools:vscode-sidecar-latest" }}
           imagePullPolicy: Always
           securityContext:
             readOnlyRootFilesystem: false
@@ -130,8 +130,13 @@ spec:
               done
               # 2) Tooling dev (prefijo relocatable → volumen compartido). El guard
               #    hace no-op con imágenes viejas del sidecar (sin /opt/adhoc-dev).
+              #    Copiamos los CONTENIDOS (dotglob para incluir .agents/) sin
+              #    preservar ownership/timestamps: la raíz del emptyDir es root:root
+              #    y el seed corre como odoo no-root (chown/utime en la raíz → EPERM).
               if [ -d /opt/adhoc-dev ]; then
-                cp -a /opt/adhoc-dev/. /work/dev-tools/
+                shopt -s dotglob
+                cp -a --no-preserve=ownership,timestamps /opt/adhoc-dev/* /work/dev-tools/
+                shopt -u dotglob
                 echo "Seeded /opt/adhoc-dev -> /work/dev-tools ($(ls /work/dev-tools/bin 2>/dev/null | wc -l) bins)"
               fi
           volumeMounts:
@@ -170,17 +175,25 @@ spec:
               PREFIX=/opt/adhoc-dev
               if [ -d "$PREFIX/bin" ]; then
                 # CLIs → ~/.local/bin: ya está en PATH tanto en login como no-login
-                # (evita pelearse con el reset de PATH de /etc/profile).
+                # (evita pelearse con el reset de PATH de /etc/profile). Symlink al
+                # prefijo ro: los binarios no se reescriben.
                 mkdir -p "$HOME/.local/bin"
                 for b in "$PREFIX"/bin/*; do ln -sfn "$b" "$HOME/.local/bin/$(basename "$b")"; done
-                # skills → ~/.claude/skills (Claude Code) y ~/.agents/skills (codex/gemini)
-                mkdir -p "$HOME/.claude" "$HOME/.agents"
-                ln -sfn "$PREFIX/.agents/skills" "$HOME/.claude/skills"
-                ln -sfn "$PREFIX/.agents/skills" "$HOME/.agents/skills"
-                # templates fallback AGENTS.md / CLAUDE.md / GEMINI.md
+                # skills + templates → COPIAS writable en HOME (NO symlink al mount ro):
+                # `adhoc-way init` y la CLI de skills gestionan estas rutas, y escribir
+                # a través de un symlink al prefijo ro daría EROFS.
+                mkdir -p "$HOME/.claude/skills" "$HOME/.agents/skills"
+                cp -a --no-preserve=ownership,timestamps "$PREFIX"/.agents/skills/. "$HOME/.claude/skills/"
+                cp -a --no-preserve=ownership,timestamps "$PREFIX"/.agents/skills/. "$HOME/.agents/skills/"
                 for f in AGENTS.md CLAUDE.md GEMINI.md; do
-                  [ -f "$PREFIX/agents-templates/$f" ] && ln -sfn "$PREFIX/agents-templates/$f" "$HOME/$f"
+                  [ -f "$PREFIX/agents-templates/$f" ] && cp -a "$PREFIX/agents-templates/$f" "$HOME/$f"
                 done
+                # Registrar los hooks user-level de los agentes (idempotente,
+                # non-interactive). best-effort + timeout: init NO debe colgar ni
+                # tumbar el pod (p.ej. si el paso de skills necesita egress y no
+                # está). La identidad queda pendiente (skeleton); el dev la completa
+                # en el primer "hola" al agente (agent-mediated vía tuqui-adhoc).
+                timeout 180 "$PREFIX/bin/adhoc-way" init || echo "adhoc-way init: warning best-effort, continúo"
               fi
               exec sleep infinity
           {{ end }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -422,6 +422,9 @@ adhoc:
   appType: prod
   clientAnalyticAccount: "Unknown"
   devMode: false
+  # Imagen del sidecar que, en devMode, siembra el VS Code server + el tooling de
+  # agentes IA (node, adhoc-way, skills, CLIs) en el pod. Ver doc/adhoc-odoo.md.
+  sidecarImage: adhoc/ops-tools:vscode-sidecar-latest
   # (adhoc.dnsBannedHost eliminado junto con su ConfigMap /etc/hosts y el mount del
   # Deployment. En modo enforce el egress queda controlado por el whitelist deny-by-default
   # — ya no hay sinkhole por /etc/hosts. Blacklist explícito: follow-up por EnvoyFilter.)


### PR DESCRIPTION
## Qué

Completa y corrige el **seed de tooling dev en `devMode`** del chart `adhoc-odoo`. Una versión intermedia entró incidentalmente en #91 (barrida por un `git add .` en el checkout compartido); esto la lleva al **estado final validado en cluster01**. Parte del task #68170.

## Cambios

- **initContainer `seed-vscode-server`**: además del VS Code server, siembra el prefijo relocatable del sidecar (`/opt/adhoc-dev`) al volumen `dev-tools`. **Fix del `cp` que daba EPERM**: copiar contenidos con `dotglob` + `--no-preserve=ownership,timestamps` (la raíz del `emptyDir` es `root:root` y el seed corre como odoo no-root → `chown`/`utime` en la raíz fallaban y con `set -e` tumbaban el initContainer).
- **container odoo (`devMode`)**: monta `dev-tools` en `/opt/adhoc-dev` (ro) + un bootstrap que:
  - symlinkea los CLIs a `~/.local/bin` (ya está en PATH en login y no-login → evita el reset de PATH de `/etc/profile`),
  - copia skills/templates a HOME **writable** (evita `EROFS` al gestionarlas — un symlink al mount ro rompía `adhoc-way init`),
  - corre `adhoc-way init` **best-effort** (`timeout` + `|| true`) para dejar los hooks user-level listos sin poder colgar/tumbar el pod.
- **`adhoc.sidecarImage`**: value nuevo para parametrizar la imagen del sidecar (default `vscode-sidecar-latest`).

Backward-compatible: los guards (`[ -d /opt/adhoc-dev ]`, `[ -d $PREFIX/bin ]`) hacen no-op con imágenes viejas del sidecar.

## Test plan

- `helm lint` + `helm template` OK; pre-commit (yamllint + helm validate) OK.
- Validado end-to-end en un tenant de **test** (cluster01) vía `helm upgrade --reuse-values`: seed OK, tooling en PATH (login y no-login), 6+ skills en `~/.claude/skills`, `adhoc-way init` auto-registrando hooks en el arranque, venv de odoo intacto.

## Complementa

Requiere la imagen del sidecar con el prefijo `/opt/adhoc-dev` → PR ingadhoc/devops-ops-tools#28. El chart toma la imagen vía `adhoc.sidecarImage` (o el default `-latest` una vez publicada).