### PR TITLE
fix: excluir el metadata server del sidecar (Workload Identity/gcsfuse bajo enforce)

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -255,3 +255,21 @@ podAnnotations lo maneja cada template; este helper es el DEFAULT.
 {{- end -}}
 {{- join "," $ports -}}
 {{- end -}}
+
+{{/*
+adhoc-odoo.egressExcludeIPRanges — IPs que se SACAN del redirect del sidecar (salen directo).
+Baseline: el metadata server de GKE (169.254.169.254). La Workload Identity de gcsfuse lo consulta
+por HTTP:80; bajo enforce (REGISTRY_ONLY) el sidecar no tiene ServiceEntry para él → 502 → gcsfuse
+no obtiene el token → el mount cuelga → el pod NO ARRANCA. Excluirlo del mesh lo resuelve (queda
+gobernado por la NetworkPolicy, que ya permite link-local). Se le suman los CIDRs extra que el
+tenant declare en egress.excludeOutboundIPRanges.
+*/}}
+{{- define "adhoc-odoo.egressExcludeIPRanges" -}}
+{{- $egress := (.Values.ingress.istio.egress | default dict) -}}
+{{- $ranges := list "169.254.169.254/32" -}}
+{{- range (splitList "," ($egress.excludeOutboundIPRanges | default "")) -}}
+{{- $r := trim . -}}
+{{- if and $r (not (has $r $ranges)) -}}{{- $ranges = append $ranges $r -}}{{- end -}}
+{{- end -}}
+{{- join "," $ranges -}}
+{{- end -}}

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -79,6 +79,12 @@ spec:
         # configurado (odoo.smtp.port) se auto-incluye. Ver doc/adhoc-odoo.md.
         traffic.sidecar.istio.io/excludeOutboundPorts: {{ include "adhoc-odoo.egressExcludePorts" . | quote }}
         {{- end }}
+        {{- /* Metadata server de GKE (169.254.169.254): la Workload Identity de gcsfuse lo consulta
+           por HTTP:80; bajo enforce el sidecar lo bloquea (502) → gcsfuse no monta → el pod no arranca.
+           Se saca del redirect del sidecar (queda gobernado por la NetworkPolicy). Ver doc/adhoc-odoo.md. */}}
+        {{- if not (hasKey (.Values.podAnnotations | default dict) "traffic.sidecar.istio.io/excludeOutboundIPRanges") }}
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: {{ include "adhoc-odoo.egressExcludeIPRanges" . | quote }}
+        {{- end }}
         {{- end }}
         rollme: {{ include "adhoc-odoo.releaseDigest" . }} # Force redeploy on change
         {{- if ne .Values.adhoc.appType "prod" }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -93,6 +93,11 @@ ingress:
       # El puerto SMTP configurado (odoo.smtp.port) se AUTO-INCLUYE (cubre relays en puertos no
       # estándar sin tocar esta lista). Ver "Egress control" en doc/adhoc-odoo.md.
       excludeOutboundPorts: "587,465,25,22,2525"
+      # IPs que se SACAN del redirect del sidecar (salen directo, gobernadas por la NetworkPolicy).
+      # El metadata server de GKE (169.254.169.254) SIEMPRE se excluye (baked-in): la Workload
+      # Identity de gcsfuse lo consulta por HTTP:80 y bajo enforce el sidecar lo bloquearía (502) →
+      # gcsfuse no montaría → el pod no arranca. Acá se agregan CIDRs EXTRA (raro). Ver doc.
+      excludeOutboundIPRanges: ""
       # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP del tenant, etc.). No se
       # puede derivar de un hostname; usar el rango publicado del proveedor o la IP del relay.
       outboundTcpCidrs: []

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -70,6 +70,7 @@ ingress:
                                 #   (client-first: HTTP/PG/Redis/465...). NO server-first, NO 80/443
       # SMTP/SSH (server-first) se sacan del sidecar y se gobiernan por NetworkPolicy (no ServiceEntry):
       excludeOutboundPorts: "587,465,25,22,2525"  # bypassan el sidecar; odoo.smtp.port se auto-incluye
+      excludeOutboundIPRanges: ""  # IPs extra fuera del redirect; el metadata server (169.254.169.254) ya va baked-in
       outboundTcpCidrs: []      # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP)
       repoSsh: true             # enforce: agrega CIDRs de GitHub SSH a la NP, SOLO con adhoc.devMode
                                 #   (no-op en prod). Default true → devMode abre GitHub:22; false para dev sin SSH
@@ -130,6 +131,10 @@ queda excluido sin tener que editar `excludeOutboundPorts`:
 
 Notas:
 
+- **Metadata server / Workload Identity.** El metadata server de GKE (`169.254.169.254`, HTTP:80)
+  se saca del redirect del sidecar (`excludeOutboundIPRanges`, baked-in). gcsfuse lo consulta para
+  la WI; bajo `enforce` el sidecar (REGISTRY_ONLY) lo bloquearía (**502**) → gcsfuse no monta → el
+  pod **no arranca**. Excluirlo lo deja gobernado por la NetworkPolicy (que ya permite link-local).
 - **allowedHosts** se puebla desde el inventario del modo `observe`.
 - **repoHosts** se suman solo si `odoo.entrypoint.repos` no está vacío (default github en el
   template, vale bajo `--reuse-values`; sobreescribible para gitlab/etc.).


### PR DESCRIPTION
## Problema (enforce no arranca — causa raíz real del incidente gcsfuse)

El metadata server de GKE (`169.254.169.254`, **HTTP:80**) lo consulta la **Workload Identity** de gcsfuse para obtener el token. Bajo `enforce` (`REGISTRY_ONLY`) el sidecar no tiene ServiceEntry para él → **502**:

```
sidecar bucket access check error: failed to setup metadata service:
failed to get project: compute: Received 502 for identity pool "nubeadhoc.svc.id.goog"
and identity provider "https://container.googleapis.com/.../clusters/cluster01"
```

→ gcsfuse no obtiene el token → el mount cuelga (`transport endpoint is not connected`) → `CreateContainerError` → **el pod de Odoo NO arranca**. En `observe` (`ALLOW_ANY`) el metadata pasa por passthrough, por eso el bug es **enforce-only** (y por eso los tenants en observe andaban).

Este era el eslabón que faltaba: #87 (namespaceSelector) hace que el *proxy* arranque, pero después el metadata:80 bloqueado tumbaba gcsfuse.

## Fix

`traffic.sidecar.istio.io/excludeOutboundIPRanges: "169.254.169.254/32"` (baked-in) — saca el metadata del redirect del sidecar; queda gobernado por la NetworkPolicy (que ya permite link-local). Nuevo helper `egressExcludeIPRanges` + value `egress.excludeOutboundIPRanges` para CIDRs extra. El override de `podAnnotations` gana. Se emite en observe+enforce (no-op en observe, consistente).

## Validación (cluster01, test2 en enforce)
- Sin el fix: metadata `169.254.169.254:80` → **HTTP 502**; pod odoo → `CreateContainerError` (2/3, gcsfuse no monta).
- Con el fix: metadata → **HTTP 200** (project-id + WI token); pod odoo → **3/3 Running**, gcsfuse montó, `storage.googleapis.com` → 400 (real), `example.com:443` → BlackHole. ✅
- `helm lint` ✅, render OK, sin bump.

> **Recomendación:** ya van varios fixes enforce-críticos bajo el mismo `0.3.4` (#87, #90, #91, este). Convendría **bumpear** el chart para poder gatear "enforce usable ≥ X.Y.Z" y trackear qué tenants lo tienen.

Sigue #85/#86/#87/#88/#89/#90/#91.