### PR TITLE
chore: OWC — bump adhoc-wakeup-controller a 0.4.1 (image .29)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.4.0
+version: 0.4.1
 
-appVersion: "odooWakeupController-2026.06.25.26"
+appVersion: "odooWakeupController-2026.07.04.29"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.06.25.26
+  tag: odooWakeupController-2026.07.04.29
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump del chart `adhoc-wakeup-controller` **0.4.0 → 0.4.1**, appVersion e `image.tag` a `odooWakeupController-2026.07.04.29`.

Imagen del build post-merge de [ingadhoc/devops-ops-tools#29](https://github.com/ingadhoc/devops-ops-tools/pull/29): `on_create` despierta la instancia al reactivar una base que estaba dormida (fix validado con canary). Tarea 70482.

Al mergear, el workflow `helm.yml` publica 0.4.1 a gh-pages. Después se bumpea `chartVersion` en devops-cloud-infra (prod-apps) y se hace `pulumi up`.