### PR TITLE
fix: OWC — desactivar OWC resiliente cuando min=0 (en vez de romper el render)

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -187,15 +187,22 @@ Restoring the database we need to scale down to 0, so if replicaCount is set to 
 {{- end -}}
 
 {{/*
-wakeupController.enabled — true when KEDA + wakeup controller are both active
-and minReplicas is 0 (scale-to-zero mode).
+wakeupController.enabled — true when KEDA + wakeup controller are both active,
+minReplicas>=1, and controllerSvc is set. The OWC owns the 1→0 transition, so KEDA
+is pinned at floor>=1 (never scales to 0 on its own); the OWC lowers the floor to 0
+and scales down itself when idle, and back to 1 on wakeup.
+
+Resilient by design: minReplicas>=1 is a CONDITION here, NOT a hard validation. If an
+instance ends up OWC-enabled with minReplicas=0 (e.g. mid-migration of the values),
+this returns false → the OWC is silently disabled and the instance falls back to
+KEDA-owned scale-to-zero (woken by the HTTP interceptor) instead of failing to render.
 */}}
 {{- define "wakeupController.enabled" -}}
 {{- $wc := .Values.autoscaling.wakeupController | default dict -}}
 {{- and
     (eq (include "keda.enabled" . | trim) "true")
     ($wc.enabled | default false)
-    (eq (.Values.autoscaling.minReplicas | int) 0)
+    (ge (.Values.autoscaling.minReplicas | int) 1)
     (ne ($wc.controllerSvc | default "") "")
 -}}
 {{- end -}}

--- a/charts/adhoc-odoo/templates/validate.yaml
+++ b/charts/adhoc-odoo/templates/validate.yaml
@@ -35,15 +35,18 @@ Debe existir nombre de base de datos.
 {{- /*
 wakeupController: keda es prerrequisito, pero no es un error tenerlo apagado.
 Si keda está desactivado, el wakeup controller queda deshabilitado
-automáticamente (lo resuelve el helper "wakeupController.enabled"), así que su
-configuración solo se valida cuando keda está efectivamente activo.
+automáticamente (lo resuelve el helper "wakeupController.enabled").
+
+Resiliente por diseño: NO se hace `fail` por la inconsistencia OWC + minReplicas.
+El OWC es dueño del 1→0, así que requiere minReplicas>=1; si una base queda
+OWC-on + min=0 (ej. a mitad de la migración de values), el helper
+"wakeupController.enabled" devuelve false y el OWC se desactiva solo (cae a KEDA
+scale-to-zero + HTTP interceptor) en vez de romper el render. Acá solo se valida
+que, si el OWC quiere activarse, tenga controllerSvc.
 */ -}}
 {{- $wc := .Values.autoscaling.wakeupController | default dict -}}
 {{- if and ($wc.enabled | default false) (eq (include "keda.enabled" . | trim) "true") -}}
 {{- if eq ($wc.controllerSvc | default "") "" -}}
 {{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.wakeupController.controllerSvc to be set (use the FQDN from the adhoc-wakeup-controller chart NOTES)." -}}
-{{- end -}}
-{{- if ne (.Values.autoscaling.minReplicas | int) 0 -}}
-{{- fail "autoscaling.wakeupController.enabled=true requires autoscaling.minReplicas=0 (scale-to-zero mode)." -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Qué

Hace **resiliente** el acople OWC ↔ `minReplicas` en el chart `adhoc-odoo`, alineado con la decisión: **con el OWC habilitado, el OWC es dueño del 1→0**, así que corre con `minReplicas>=1` (KEDA clavado en piso, nunca escala a 0 solo).

## Cambio (sin bump — update in-place de 0.3.4)

- `_helpers.tpl` → `wakeupController.enabled` ahora exige `minReplicas>=1` (antes exigía `==0`). Es una **condición**, no una validación dura.
- `validate.yaml` → se **quita el `fail`** por la inconsistencia OWC+min. Resiliente > error duro; queda solo la validación de `controllerSvc`.

**Resiliencia:** si una base queda OWC-on + `min=0` (ej. a mitad de la migración de values), el helper devuelve `false` → el OWC se **desactiva solo** y la instancia cae a KEDA scale-to-zero + HTTP interceptor, **sin romper el render**.

## Pruebas (`helm template`)

| Caso | Resultado |
|---|---|
| OWC + min=1 | OWC activo (WakeupInstance + ScaledObject min=1) |
| OWC + min=0 | **sin fail** → OWC off, InterceptorRoute + min=0 (KEDA) |
| train (no-OWC + min=0) | InterceptorRoute + min=0 |
| prod (no-OWC + min=1) | sin OWC/interceptor |

`helm lint` limpio.

## Contexto

Cambio atómico con los values del SaaS (`autoscaling.minReplicas = 1 if Production or wakeupController.enabled`, ya aplicados) — invierten juntos el acople "OWC⟺min=0". Al mergear, `helm.yml` republica `adhoc-odoo-0.3.4` in-place; verificar que el índice de gh-pages tome el nuevo digest. Tarea 70484.
