### PR TITLE
fix: quitar report.url inerte de los ConfigMaps de conf en Odoo 19

### DIFF
--- a/charts/adhoc-odoo/changelog.md
+++ b/charts/adhoc-odoo/changelog.md
@@ -10,6 +10,11 @@ Fixes:
   --reuse-values` sobre una instancia legacy anterior a #74). Antes el render
   fallaba con `nil pointer evaluating interface {}.domain`. Regresión cubierta
   por el fixture `ci/legacy-no-wakeupcontroller-values.yaml`.
+- Odoo 19: quitado `report.url` de los ConfigMaps de conf (`odooExtraConf` y
+  `odoo-send-file`). En 19 Odoo lo lee del `ir.config_parameter`, no del
+  odoo.conf, así que la línea era inerte y solo generaba el warning de arranque
+  `unknown option 'report.url'`. `x_sendfile=True` se mantiene; en 18
+  `report.url` queda intacto (gateado a `<190`).
 
 Features:
 

--- a/charts/adhoc-odoo/templates/odoo/odooExtraConf.yaml
+++ b/charts/adhoc-odoo/templates/odoo/odooExtraConf.yaml
@@ -10,7 +10,5 @@ data:
   odoo-extra.conf: |
     [options]
       log_handler = :INFO,odoo.addons.rpc.controllers.jsonrpc:ERROR
-{{- if not .Values.ingress.reverseProxy.enabled }}
-      report.url = http://{{ include "adhoc-odoo.serviceNameSuffix" . }}-http.{{ .Release.Namespace }}
-{{- end }}
+{{- /* report.url quitado: este CM es solo 19+, y en 19 Odoo lo lee del ICP, no del conf (inerte) -> solo generaba warning */}}
 {{- end }}

--- a/charts/adhoc-odoo/templates/reverseProxy/odoo_cm.yaml
+++ b/charts/adhoc-odoo/templates/reverseProxy/odoo_cm.yaml
@@ -10,5 +10,8 @@ data:
   odoo-send-file.conf: |
     [options]
       x_sendfile = True
+{{- /* report.url solo <19: en 19+ Odoo lo lee del ICP, no del conf (inerte) -> solo generaba warning */}}
+{{- if lt $odooVersion 190 }}
       report.url = http://{{ include "adhoc-odoo.serviceNameSuffix" . }}-nginx.{{ .Release.Namespace }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Qué

Saca `report.url` de los ConfigMaps de conf del chart `adhoc-odoo` para Odoo 19:

- `templates/odoo/odooExtraConf.yaml` (CM `>=190`): se quita la línea `report.url` (queda `log_handler`).
- `templates/reverseProxy/odoo_cm.yaml` (send-file, `>=180`, compartido con 18): `report.url` gateado a `{{- if lt $odooVersion 190 }}` → se saca en 19, **se mantiene en 18**. `x_sendfile = True` se mantiene siempre.

## Por qué

En 17/18/19 Odoo lee `report.url` del **`ir.config_parameter`**, no del odoo.conf (`ir_actions_report._get_report_url` → `get_param('report.url') or get_base_url()`). La línea del conf era inerte en 19 y solo generaba el `WARNING ... unknown option 'report.url'` en cada arranque. Confirmado en vivo: sacar `report.url` + `report.url.freeze` del conf de una base de test e imprimir un reporte sigue funcionando (el ICP no está seteado → cae a `web.base.url`, comportamiento deseado; setearlo interno reintroduce el loop de workers OEP/Istio).

`x_sendfile=True` es nativo (`odoo/http.py` → `config['x_sendfile']`) y esencial — no se toca.

## Prueba

`helm template` validado:
- v19 (reverseProxy on/off): sin `report.url`, con `x_sendfile`.
- v18 (reverseProxy on): `report.url` presente (intacto).
- Render completo sin errores; pre-commit (yamllint + helm lint) OK.

Backward-compat → sin bump de version.

Companion del PR en `oci-odoo-by-adhoc` que saca `report.url` del `95-adhoc.conf` del image. Tarea 69824.