### PR TITLE
fix: restituir report.url por sección según imagen (compat [adhoc] vs [options])

### DIFF
--- a/charts/adhoc-odoo/changelog.md
+++ b/charts/adhoc-odoo/changelog.md
@@ -10,11 +10,14 @@ Fixes:
   --reuse-values` sobre una instancia legacy anterior a #74). Antes el render
   fallaba con `nil pointer evaluating interface {}.domain`. Regresión cubierta
   por el fixture `ci/legacy-no-wakeupcontroller-values.yaml`.
-- Odoo 19: quitado `report.url` de los ConfigMaps de conf (`odooExtraConf` y
-  `odoo-send-file`). En 19 Odoo lo lee del `ir.config_parameter`, no del
-  odoo.conf, así que la línea era inerte y solo generaba el warning de arranque
-  `unknown option 'report.url'`. `x_sendfile=True` se mantiene; en 18
-  `report.url` queda intacto (gateado a `<190`).
+- Odoo 19: `report.url` se coloca en la sección de conf según la imagen. Corrige
+  la suposición previa de que era inerte: `server_global_parameters` (ADHOC SA)
+  lo lee del odoo.conf vía `get_param`, así que quitarlo cambiaba el
+  comportamiento (afecta wkhtml2pdf). Ahora: imágenes 19 `>= 20260707` (con el
+  `server_global_parameters` que lee la sección `[adhoc]`) lo reciben bajo
+  `[adhoc]` (sin warning `unknown option`); imágenes 18 y 19 anteriores lo
+  reciben bajo `[options]` (compatibilidad con el módulo previo). `x_sendfile=True`
+  queda siempre en `[options]`.
 
 Features:
 

--- a/charts/adhoc-odoo/templates/odoo/odooExtraConf.yaml
+++ b/charts/adhoc-odoo/templates/odoo/odooExtraConf.yaml
@@ -1,4 +1,5 @@
 {{- $odooVersion := include "adhoc-odoo.odoo-version" . | replace "." "" | int -}}
+{{- $minorVersion := include "adhoc-odoo.odoo-minor-version" . | int }}
 {{- if ge $odooVersion 190 }}
 apiVersion: v1
 kind: ConfigMap
@@ -10,5 +11,14 @@ data:
   odoo-extra.conf: |
     [options]
       log_handler = :INFO,odoo.addons.rpc.controllers.jsonrpc:ERROR
-{{- /* report.url quitado: este CM es solo 19+, y en 19 Odoo lo lee del ICP, no del conf (inerte) -> solo generaba warning */}}
+{{- if not .Values.ingress.reverseProxy.enabled }}
+{{- /* report.url (reverseProxy off): imágenes >= 20260707 leen [adhoc] via server_global_parameters; viejas -> [options] */}}
+{{- if ge $minorVersion 20260707 }}
+
+    [adhoc]
+      report.url = http://{{ include "adhoc-odoo.serviceNameSuffix" . }}-http.{{ .Release.Namespace }}
+{{- else }}
+      report.url = http://{{ include "adhoc-odoo.serviceNameSuffix" . }}-http.{{ .Release.Namespace }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/reverseProxy/odoo_cm.yaml
+++ b/charts/adhoc-odoo/templates/reverseProxy/odoo_cm.yaml
@@ -1,4 +1,5 @@
 {{- $odooVersion := include "adhoc-odoo.odoo-version" . | replace "." "" | int -}}
+{{- $minorVersion := include "adhoc-odoo.odoo-minor-version" . | int }}
 {{- if and .Values.ingress.reverseProxy.enabled (ge $odooVersion 180) }}
 apiVersion: v1
 kind: ConfigMap
@@ -10,8 +11,12 @@ data:
   odoo-send-file.conf: |
     [options]
       x_sendfile = True
-{{- /* report.url solo <19: en 19+ Odoo lo lee del ICP, no del conf (inerte) -> solo generaba warning */}}
-{{- if lt $odooVersion 190 }}
+{{- /* report.url: imágenes 19 >= 20260707 tienen server_global_parameters que lee [adhoc] -> va en [adhoc]; 18 y 19 viejas usan el módulo viejo -> [options] */}}
+{{- if and (ge $odooVersion 190) (ge $minorVersion 20260707) }}
+
+    [adhoc]
+      report.url = http://{{ include "adhoc-odoo.serviceNameSuffix" . }}-nginx.{{ .Release.Namespace }}
+{{- else }}
       report.url = http://{{ include "adhoc-odoo.serviceNameSuffix" . }}-nginx.{{ .Release.Namespace }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Qué

Revierte la remoción de #96, pero colocando `report.url` en la sección de conf **según la imagen**:

| Imagen | Sección | Módulo que lo lee |
|---|---|---|
| 19 `>= 20260707` | `[adhoc]` | `server_global_parameters` que lee `[adhoc]` ([odoo-saas#849](https://github.com/ingadhoc/odoo-saas/pull/849)) — sin warning `unknown option` |
| 18 y 19 anteriores | `[options]` | `server_global_parameters` viejo (fallback a `[options]`) — compat |

`x_sendfile=True` queda **siempre** en `[options]`. Aplica a `odoo-send-file` (reverseProxy on) y `odoo-extra` (reverseProxy off).

## Por qué

#96 quitó `report.url` creyéndolo inerte. **No lo era:** `server_global_parameters` (ADHOC SA) lo lee del conf vía `get_param`, así que quitarlo cambió el comportamiento (afecta wkhtml2pdf). Este PR lo restituye manteniendo **compatibilidad**: imágenes viejas siguen leyéndolo de `[options]`; las nuevas (con #849) de `[adhoc]` sin ensuciar el arranque.

## Validación

`helm template` en los 5 casos (19≥hoy on/off → `[adhoc]`; 19<hoy y 18 → `[options]`) + `helm lint` OK.

## Coordinación

El gate `>= 20260707` asume que las imágenes 19 de esa fecha en adelante traen #849. Mergear/servir junto con #849 en `odoo-saas@19.0`. Sin bump (backward-compat).

Tarea 69824.