### PR TITLE
fix: startupProbe httpGet healthz en instancias KEDA

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -208,18 +208,19 @@ spec:
           # https://v1-18.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
           # Waits the pod to be ready on startup, important during modules installation or running "fixdb"
           startupProbe:
-            # - if $isKedaEnabled
-            # httpGet:
-            #   {{- if ge $odooVersion 180 }}
-            #   path: /saas_client/healthz
-            #   {{- else }}
-            #   path: /web/health
-            #   {{- end }}
-            #   port: 8069
-            # - else
+            {{- if $isKedaEnabled }}
+            # healthz gates readiness to a worker that can serve a DB-backed request
+            httpGet:
+              {{- if ge $odooVersion 180 }}
+              path: /saas_client/healthz
+              {{- else }}
+              path: /web/health
+              {{- end }}
+              port: 8069
+            {{- else }}
             tcpSocket:
               port: 8069
-            # - end
+            {{- end }}
             initialDelaySeconds: 1
             failureThreshold: 900 # 15 min
             periodSeconds: 1


### PR DESCRIPTION
## Qué

Cambia el `startupProbe` del deployment de Odoo de `tcpSocket:8069` a
`httpGet /saas_client/healthz` (Odoo >=18) o `/web/health` (<18),
**solo bajo KEDA** (gateado por `$isKedaEnabled`). `readiness` y
`liveness` quedan **intactos** en `tcpSocket`.

## Por qué

`tcpSocket:8069` pasa apenas el master de Odoo bindea el socket —
antes de que existan workers, y con el pre-warm de assets hasta ~90s
antes de que el pod pueda servir un request. Eso marca el pod `Ready`
mientras está muerto. Con el rolling update actual
(`maxSurge:1, maxUnavailable:0`), el pod viejo se termina apenas el
nuevo se marca `Ready` → el tráfico cae en el pod nuevo que todavía no
tiene worker (hangs / 500 / assets faltantes).

`healthz` hace `SELECT 1` sobre el cursor: readiness recién pasa cuando
un worker atiende un request con DB. Así el rolling update mantiene el
pod viejo sirviendo hasta que el nuevo está realmente warm, y el pod no
entra a los endpoints del Service mientras no puede servir.

Se deja **fuera** de `readiness`/`liveness` a propósito: ponerlo ahí
acoplaría la rotación del pod a que haya workers libres (un pod
momentáneamente saturado quedaría not-ready / lo mataría liveness).

## Medición (trainp-grittiagrimensura, v19, con pre-warm)

| Escenario | `tcpSocket` (ventana Ready→puede-servir) | `httpGet healthz` |
|---|---|---|
| restart steady-state | ~19s | ~0-2s |
| post-deploy (regen assets) | ~98s | ~0 |

El pod deja de anunciarse `Ready` estando muerto; con `maxSurge` el
costo del pre-warm queda oculto detrás del pod viejo (cutover a un pod
ya warm, sin downtime).

Backward-compat: sin KEDA el probe sigue siendo `tcpSocket` (sin bump
de versión del chart).

Tarea 70607.