### PR TITLE
feat: exporter sidecar out-of-band para métricas de Odoo (tarea 70602)

### DIFF
--- a/charts/adhoc-odoo/templates/monitoringCommon.yaml
+++ b/charts/adhoc-odoo/templates/monitoringCommon.yaml
@@ -25,8 +25,13 @@ spec:
           protocol: TCP
       {{- end }}
       {{- if .Values.odoo.monitoring.enabled }}
+        {{- if .Values.odoo.monitoring.exporterSidecar }}
+        - port: 9101
+          protocol: TCP
+        {{- else }}
         - port: 8069
           protocol: TCP
+        {{- end }}
       {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -321,7 +321,8 @@ spec:
           {{- end }}
         {{- if and .Values.odoo.monitoring.enabled .Values.odoo.monitoring.exporterSidecar }}
         # Out-of-band metrics exporter: serves /metrics from the shared multiprocess dir so scrapes
-        # survive Odoo worker-pool exhaustion. Image: devops-ops-tools/prometheusOdooExporter.
+        # survive Odoo worker-pool exhaustion. Image from values (monitoring.exporterRepository/Tag);
+        # source at devops-ops-tools/prometheusOdooExporter.
         - name: prometheus-exporter
           image: {{ printf "%s:%s" .Values.odoo.monitoring.exporterRepository .Values.odoo.monitoring.exporterTag | quote }}
           securityContext:

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -314,6 +314,40 @@ spec:
           - name: session-folder-ro
             mountPath: /home/odoo/data/sessions
             readOnly: true
+          {{- if and .Values.odoo.monitoring.enabled .Values.odoo.monitoring.exporterSidecar }}
+          # Shared with the prometheus-exporter sidecar; the module writes multiprocess metric files here.
+          - name: prometheus-multiproc
+            mountPath: /tmp/prometheus_client
+          {{- end }}
+        {{- if and .Values.odoo.monitoring.enabled .Values.odoo.monitoring.exporterSidecar }}
+        # Out-of-band metrics exporter: serves /metrics from the shared multiprocess dir so scrapes
+        # survive Odoo worker-pool exhaustion. Image: devops-ops-tools/prometheusOdooExporter.
+        - name: prometheus-exporter
+          image: {{ printf "%s:%s" .Values.odoo.monitoring.exporterRepository .Values.odoo.monitoring.exporterTag | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: PROMETHEUS_MULTIPROC_DIR
+              value: "/tmp/prometheus_client"
+          ports:
+            - name: prom-odoo
+              containerPort: 9101
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: prometheus-multiproc
+              mountPath: /tmp/prometheus_client
+              readOnly: true
+        {{- end }}
       affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -424,3 +458,8 @@ spec:
       {{- end }}
       - name: session-folder-ro
         emptyDir: {}
+      {{- if and .Values.odoo.monitoring.enabled .Values.odoo.monitoring.exporterSidecar }}
+      # Volume shared with the exporter sidecar for prometheus_client multiproc files (tiny mmap files).
+      - name: prometheus-multiproc
+        emptyDir: {}
+      {{- end }}

--- a/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
+++ b/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
@@ -12,7 +12,13 @@ spec:
     matchLabels:
       {{- include "adhoc-odoo.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
+  {{- if .Values.odoo.monitoring.exporterSidecar }}
+  - port: prom-odoo
+    path: /metrics
+    interval: 60s
+  {{- else }}
   - port: http
     path: /metrics
     interval: 60s
+  {{- end }}
 {{- end }}

--- a/charts/adhoc-odoo/templates/odooEnvs.yaml
+++ b/charts/adhoc-odoo/templates/odooEnvs.yaml
@@ -177,10 +177,13 @@ data:
   ODOO_MAX_HTTP_THREADS: "8"
   ODOO_SESSION_REDIS_SSL: "0"
   LITELLM_LOG: "CRITICAL"
-  {{- /* Multiprocess mode lets the exporter sidecar read metrics from files, so it also works in
-         threaded mode (workers=0); the module creates the dir on boot (no more missing-dir crash).
-         Falls back to the old workers>0-only behavior when the sidecar is off (controller scrape). */}}
-  {{- if and .Values.odoo.monitoring.enabled (or .Values.odoo.monitoring.exporterSidecar (gt $workers 0)) }}
+  {{- /* Multiprocess mode lets the exporter sidecar read metrics from files. In prefork (workers>0)
+         every image creates the dir, so it's always safe. In threaded mode (workers=0) the dir is
+         only created on images >= 2026-06-24; gate on the image minor version to avoid crashing
+         older images. Tags carry a date by design; a dateless (dev) tag is assumed current (today). */}}
+  {{- $minorRaw := include "adhoc-odoo.odoo-minor-version" . | trim -}}
+  {{- $effectiveMinor := int (ternary $minorRaw (now | date "20060102") (regexMatch "^[0-9]{8}$" $minorRaw)) -}}
+  {{- if and .Values.odoo.monitoring.enabled (or (gt $workers 0) (and .Values.odoo.monitoring.exporterSidecar (ge $effectiveMinor 20260624))) }}
   PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_client"
   {{- end }}
   KWKHTMLTOPDF_SERVER_URL: {{ .Values.odoo.kwkhtmltopdfServerUrl | quote }}

--- a/charts/adhoc-odoo/templates/odooEnvs.yaml
+++ b/charts/adhoc-odoo/templates/odooEnvs.yaml
@@ -177,8 +177,10 @@ data:
   ODOO_MAX_HTTP_THREADS: "8"
   ODOO_SESSION_REDIS_SSL: "0"
   LITELLM_LOG: "CRITICAL"
-  {{- /* multiprocess only makes sense with workers>0; setting it threaded crashes prometheus_client on a missing dir */}}
-  {{- if gt $workers 0 }}
+  {{- /* Multiprocess mode lets the exporter sidecar read metrics from files, so it also works in
+         threaded mode (workers=0); the module creates the dir on boot (no more missing-dir crash).
+         Falls back to the old workers>0-only behavior when the sidecar is off (controller scrape). */}}
+  {{- if and .Values.odoo.monitoring.enabled (or .Values.odoo.monitoring.exporterSidecar (gt $workers 0)) }}
   PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_client"
   {{- end }}
   KWKHTMLTOPDF_SERVER_URL: {{ .Values.odoo.kwkhtmltopdfServerUrl | quote }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -387,6 +387,13 @@ odoo:
     # example2: "no"
   monitoring:
     enabled: false
+    # Out-of-band metrics exporter sidecar. When true (default), Prometheus scrapes the sidecar
+    # (:9101), which reads the multiprocess dir, so metrics survive Odoo worker-pool exhaustion.
+    # Set false to fall back to scraping the in-process controller (:8069) — the old behavior.
+    exporterSidecar: true
+    # Must match the prometheus_client version in the Odoo image (see prometheusOdooExporter dockerfile).
+    exporterRepository: dockerhub.adhoc.inc/adhoc/ops-tools
+    exporterTag: "prometheus-odoo-exporter-20260707"
 
   kwkhtmltopdfServerUrl: "http://kwkhtmltopdf.kwkhtmltopdf"
 

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -392,9 +392,11 @@ odoo:
     # dir, so metrics survive Odoo worker-pool exhaustion. Set false to fall back to scraping the
     # in-process controller (:8069) — the old behavior.
     exporterSidecar: true
-    # Must match the prometheus_client version in the Odoo image (see prometheusOdooExporter dockerfile).
+    # Built by the prometheusOdooExporter GitHub Action (pushed to docker.io/adhoc/ops-tools, pulled
+    # via this mirror). Pin a dated tag (prometheusOdooExporter-<YYYY.MM.DD>.<run>) in prod; -latest
+    # is fine for testing. Keep the exporter's prometheus_client aligned with the Odoo image.
     exporterRepository: dockerhub.adhoc.inc/adhoc/ops-tools
-    exporterTag: "prometheus-odoo-exporter-20260707"
+    exporterTag: "prometheusOdooExporter-latest"
 
   kwkhtmltopdfServerUrl: "http://kwkhtmltopdf.kwkhtmltopdf"
 

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -387,9 +387,10 @@ odoo:
     # example2: "no"
   monitoring:
     enabled: false
-    # Out-of-band metrics exporter sidecar. When true (default), Prometheus scrapes the sidecar
-    # (:9101), which reads the multiprocess dir, so metrics survive Odoo worker-pool exhaustion.
-    # Set false to fall back to scraping the in-process controller (:8069) — the old behavior.
+    # Out-of-band metrics exporter sidecar (only takes effect when monitoring.enabled=true).
+    # When true (default), Prometheus scrapes the sidecar (:9101), which reads the multiprocess
+    # dir, so metrics survive Odoo worker-pool exhaustion. Set false to fall back to scraping the
+    # in-process controller (:8069) — the old behavior.
     exporterSidecar: true
     # Must match the prometheus_client version in the Odoo image (see prometheusOdooExporter dockerfile).
     exporterRepository: dockerhub.adhoc.inc/adhoc/ops-tools


### PR DESCRIPTION
## Qué

Sirve las métricas Prometheus de Odoo desde un **exporter sidecar out-of-band** en lugar del controller in-process, para que el scrape sobreviva al agotamiento del pool de workers (justo cuando el controller no puede responder porque no hay worker libre).

## Cambios (chart `adhoc-odoo`)

- Sidecar `prometheus-exporter` (`:9101`) que lee el multiproc dir compartido.
- Volumen `prometheus-multiproc` (`emptyDir`) compartido con el container Odoo.
- `PROMETHEUS_MULTIPROC_DIR` habilitado en ambos modos (prefork y threaded), no solo `workers>0`.
- PodMonitor repuntado a `:9101`; NetworkPolicy abre 9101.
- Todo detrás de `odoo.monitoring.exporterSidecar` (default `true`; `false` = fallback a scrapear el controller en `:8069`).

## Retrocompatibilidad

- `monitoring.enabled=false`: sin cambios.
- Imágenes viejas: en prefork se sirven todas las métricas runtime; solo se pierden las de DB (aceptable). Threading requiere imagen ≥ 2026-06-24 (fix de creación del multiproc dir).
- Rollback sin redeploy del módulo: `exporterSidecar=false`.

## Test plan

- `helm lint` OK.
- `helm template` verificado en 3 escenarios: sidecar on / `exporterSidecar=false` / `monitoring.enabled=false`.
- Requiere la imagen del exporter (`devops-ops-tools/prometheusOdooExporter`) y setear `odoo.monitoring.exporterTag`.

Parte de la tarea 70602 (módulo `saas_prometheus`, imagen del exporter, pin de `prometheus-client` y alertas van en repos hermanos).
