### PR TITLE
chore: OWC — chart 0.4.2 (image .31, waiting page no-store)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.4.1
+version: 0.4.2
 
-appVersion: "odooWakeupController-2026.07.04.29"
+appVersion: "odooWakeupController-2026.07.09.31"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.07.04.29
+  tag: odooWakeupController-2026.07.09.31
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump `adhoc-wakeup-controller` 0.4.1 → 0.4.2, apuntando a la imagen `odooWakeupController-2026.07.09.31`.

Esa imagen agrega `Cache-Control: no-store` en la respuesta HTML de la waiting page: el auto-redirect del wake (`window.location.replace`) dejaba al usuario pegado en "Odoo se está despertando" sirviendo una copia cacheada del browser (probes `HEAD` daban 303 con Odoo ya arriba, pero la navegación se servía de cache; sólo se destrababa recargando a mano). Fix del código: ingadhoc/devops-ops-tools#34.

Al mergear, `helm.yml` publica 0.4.2 a gh-pages; después en Pulumi se sube `wakeupController.chartVersion` a 0.4.2 (ingadhoc/devops-cloud-infra#28). OWC corre solo en cluster01.