### PR TITLE
feat: adhoc-odoo — header x-adhoc-odoo-tier en el VirtualService

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
@@ -51,6 +51,7 @@ spec:
             x-maintenance-eta:  {{ .Values.ingress.reverseProxy.inactive.eta | default "" | quote }}
             {{- end }}
             x-adhoc-odoo-instance:  {{ .Values.odoo.pg.db  | quote }}
+            x-adhoc-odoo-tier:  {{ .Values.adhoc.appType | lower | quote }}
       route:
         - destination:
             host: {{ $srvHttp }}
@@ -138,6 +139,7 @@ spec:
             x-maintenance-eta:  {{ .Values.ingress.reverseProxy.inactive.eta | default "" | quote }}
             {{- end }}
             x-adhoc-odoo-instance:  {{ .Values.odoo.pg.db  | quote }}
+            x-adhoc-odoo-tier:  {{ .Values.adhoc.appType | lower | quote }}
       route:
         - destination:
             host: {{ $srvHttp }}


### PR DESCRIPTION
Companion del PR de OWC (`ingadhoc/devops-ops-tools#36`, puntos 2-3 de la tarea 70599).

El VirtualService ya inyecta `x-adhoc-odoo-instance`; agrego `x-adhoc-odoo-tier` (de `.Values.adhoc.appType`, misma derivación que el label `adhoc.ar/tier` del Deployment) en los **dos bloques** del VS (shared + custom). Con eso la waiting page del OWC puede elegir un template por tier.

Render verificado (`helm template ... --set adhoc.appType=Old`):
```
x-adhoc-odoo-instance:  "demo-x"
x-adhoc-odoo-tier:  "old"
```

**Sin bump de versión**: es un cambio backward-compat (solo agrega un header).

Nota: el header es plumbing — inofensivo aunque el OWC desplegado todavía no lo lea y no existan templates por tier (cae al default). Se vuelve visible cuando entre el OWC de #36 + los `www/tiers/*.html` del diseño.