### PR TITLE
chore: OWC — chart 0.4.3 (image .34: SSE + tier + spinner)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.4.2
+version: 0.4.3
 
-appVersion: "odooWakeupController-2026.07.09.31"
+appVersion: "odooWakeupController-2026.07.10.34"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.07.09.31
+  tag: odooWakeupController-2026.07.10.34
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump `adhoc-wakeup-controller` 0.4.2 → 0.4.3, apuntando a la imagen `odooWakeupController-2026.07.10.34` (buildeada desde `main` tras mergear `ingadhoc/devops-ops-tools#36`).

Trae los puntos 2-4 de la tarea 70599:
- **SSE** push del "ready" (elimina el tiempo muerto del polling; HEAD-probe queda como reaseguro).
- **Template por tier** (plumbing; lee `x-adhoc-odoo-tier`, cae al default si no hay `www/tiers/<tier>.html`).
- **Spinner** en vez de barra/contador.

El header `x-adhoc-odoo-tier` lo agrega el chart `adhoc-odoo` en `adhoc-dev/helm-charts#101` (sin bump, backward-compat).

**Deploy:** después de mergear, subir `wakeupController.chartVersion` a 0.4.3 en Pulumi (devops-cloud-infra) + `pulumi up` en el devcontainer — igual que el 0.4.2. Solo cluster01 (único con OWC).