### PR TITLE
chore: OWC — chart 0.4.4 (image .35: fix race redirect SSE + no-store assets)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.4.3
+version: 0.4.4
 
-appVersion: "odooWakeupController-2026.07.10.34"
+appVersion: "odooWakeupController-2026.07.10.35"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.07.10.34
+  tag: odooWakeupController-2026.07.10.35
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump `adhoc-wakeup-controller` 0.4.3 → 0.4.4 → imagen `odooWakeupController-2026.07.10.35` (desde `main` tras `ingadhoc/devops-ops-tools#37`).

Arregla el bug reportado en la prueba real: la recarga caía a mitad del switch del VS y mostraba la waiting page rota (sin assets) hasta recargar a mano.

- El `ready` del SSE ya no redirige a ciegas: dispara un probe rápido y solo redirige cuando el `HEAD` confirma que el gateway sirve Odoo.
- `no-store` también en los assets (antes solo el HTML/SSE) → no queda `wait.js` viejo cacheado entre deploys.

Código: `ingadhoc/devops-ops-tools#37`. Probado en local (sim `/_sim/push` reproduce el lag de propagación).

**Deploy:** al mergear, subir `wakeupController.chartVersion` a 0.4.4 en Pulumi + `pulumi up` (cluster01).