### PR TITLE
chore: OWC — chart 0.4.5 (image .36: probe redirect:manual)

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.4.4
+version: 0.4.5
 
-appVersion: "odooWakeupController-2026.07.10.35"
+appVersion: "odooWakeupController-2026.07.10.36"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.07.10.35
+  tag: odooWakeupController-2026.07.10.36
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump `adhoc-wakeup-controller` 0.4.4 → 0.4.5 → imagen `odooWakeupController-2026.07.10.36` (desde `main` tras `ingadhoc/devops-ops-tools#38`).

Arregla que la waiting page quedara pegada en el spinner cuando el Odoo de la base devuelve un `303 → http://` (el `fetch` del probe lo bloqueaba como mixed-content). Ahora el probe usa `redirect: "manual"` y no lo sigue.

Probado en cluster01 (patch directo por kubectl) con `old-agcdistribuciones-22-06-2`: levantó ok en ~25s, cayó en la login de Odoo (https).

Código: `ingadhoc/devops-ops-tools#38`.

**Deploy:** subir `wakeupController.chartVersion` a 0.4.5 en Pulumi + `pulumi up`. Esto además reconcilia el drift del patch directo (cluster01 ya corre `.36`).