### PR TITLE
feat: adhoc-odoo — priorityClassName por tier con fallback

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -6,6 +6,25 @@ Expand the name of the chart.
 {{- end }}
 
 {{- /*
+adhoc-odoo.priorityClassName — resuelve la PriorityClass del pod según adhoc.appType.
+Uso: {{ include "adhoc-odoo.priorityClassName" (dict "ctx" . "kind" "app") }}  (o "db")
+Devuelve "<appType>-priority" (app) o "<appType>-db-priority" (base) para los tiers
+conocidos (adhoc.priorityTiers, que debe espejar las clases creadas en Pulumi
+platform_resources.py). Un appType fuera de la lista cae a "default-priority": así un
+tier nuevo/desconocido schedulea normal (globalDefault) en vez de quedar Pending para
+siempre (una PriorityClass inexistente vuelve al pod no-scheduleable).
+*/}}
+{{- define "adhoc-odoo.priorityClassName" -}}
+{{- $appType := .ctx.Values.adhoc.appType | toString -}}
+{{- $known := .ctx.Values.adhoc.priorityTiers | default list -}}
+{{- if has $appType $known -}}
+{{- if eq .kind "db" -}}{{- printf "%s-db-priority" $appType -}}{{- else -}}{{- printf "%s-priority" $appType -}}{{- end -}}
+{{- else -}}
+{{- "default-priority" -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -12,7 +12,7 @@ Devuelve "<appType>-priority" (app) o "<appType>-db-priority" (base) para los ti
 conocidos (adhoc.priorityTiers, que debe espejar las clases creadas en Pulumi
 platform_resources.py). Un appType fuera de la lista cae a "default-priority": así un
 tier nuevo/desconocido schedulea normal (globalDefault) en vez de quedar Pending para
-siempre (una PriorityClass inexistente vuelve al pod no-scheduleable).
+siempre (una PriorityClass inexistente deja al pod unschedulable).
 */}}
 {{- define "adhoc-odoo.priorityClassName" -}}
 {{- $appType := .ctx.Values.adhoc.appType | toString -}}

--- a/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
@@ -57,12 +57,13 @@ metadata:
     */}}
 {{- /*https://cloudnative-pg.io/documentation/1.22/cloudnative-pg.v1/#postgresql-cnpg-io-v1-ClusterSpec */}}
 spec:
-  {{- if eq .Values.adhoc.appType "prod" }}
   {{- /*
-  # Name of the priority class which will be used in every generated Pod, if the PriorityClass specified does not exist, the pod will not be able to schedule. Please refer to https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass for more information
+  # PriorityClass de cada Pod generado. Resuelta desde appType: <appType>-db-priority
+  # para tiers conocidos, si no default-priority. Una clase inexistente dejaría el Pod
+  # sin schedulear (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).
+  # La base va un escalón sobre su Odoo (-db) para poder despejarlo si necesita el slot.
   */}}
-  priorityClassName: prod-priority
-  {{- end }}
+  priorityClassName: {{ include "adhoc-odoo.priorityClassName" (dict "ctx" . "kind" "db") }}
   # Set to 0 enable the immediate fast shutdown (bypassing the smart shutdown process)
   smartShutdownTimeout: 0
   # The time in seconds that is allowed for a PostgreSQL instance to gracefully shutdown (default 1800) We chose 3 minutes maximum

--- a/charts/adhoc-odoo/templates/cnpg/waitPg.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/waitPg.yaml
@@ -13,9 +13,7 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      {{- if eq .Values.adhoc.appType "prod" }}
-      priorityClassName: prod-priority
-      {{- end }}
+      priorityClassName: {{ include "adhoc-odoo.priorityClassName" (dict "ctx" . "kind" "app") }}
       resources:
         requests:
           cpu: 10m

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -145,9 +145,7 @@ spec:
             - name: dev-tools
               mountPath: /work/dev-tools
       {{ end }}
-      {{- if eq .Values.adhoc.appType "prod" }}
-      priorityClassName: prod-priority
-      {{- end }}
+      priorityClassName: {{ include "adhoc-odoo.priorityClassName" (dict "ctx" . "kind" "app") }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/adhoc-odoo/templates/reverseProxy/deploy.yaml
+++ b/charts/adhoc-odoo/templates/reverseProxy/deploy.yaml
@@ -65,9 +65,7 @@ spec:
         fsGroup: 101
         fsGroupChangePolicy: OnRootMismatch
 
-      {{- if eq .Values.adhoc.appType "prod" }}
-      priorityClassName: prod-priority
-      {{- end }}
+      priorityClassName: {{ include "adhoc-odoo.priorityClassName" (dict "ctx" . "kind" "app") }}
       serviceAccountName: {{ include "adhoc-odoo.serviceAccountName" . }}
       containers:
         - name: nginx

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -428,8 +428,12 @@ createPullSecret:
 adhoc:
   # standard, advanced, premium
   serviceLevel: standard
-  # Type: test, train, backup, new, old
+  # Type: prod, test, train, demo, backup, new, old, trainp, int
   appType: prod
+  # PriorityClasses generadas en Pulumi (platform_resources.py). Un appType fuera de
+  # esta lista cae a default-priority (schedulea normal en vez de romper). Mantener
+  # en sync con las clases de Pulumi.
+  priorityTiers: [prod, backup, int, new, old, test, demo, train, trainp]
   clientAnalyticAccount: "Unknown"
   devMode: false
   # Imagen del sidecar que, en devMode, siembra el VS Code server + el tooling de

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -431,8 +431,10 @@ adhoc:
   # Type: prod, test, train, demo, backup, new, old, trainp, int
   appType: prod
   # PriorityClasses generadas en Pulumi (platform_resources.py). Un appType fuera de
-  # esta lista cae a default-priority (schedulea normal en vez de romper). Mantener
-  # en sync con las clases de Pulumi.
+  # esta lista cae a default-priority (schedulea normal en vez de romper). Para un
+  # appType DENTRO de la lista deben existir en el cluster sus clases <appType>-priority
+  # y <appType>-db-priority (aplicar el cambio de Pulumi ANTES que el chart); si faltan,
+  # los pods quedan Pending. Mantener en sync con las clases de Pulumi.
   priorityTiers: [prod, backup, int, new, old, test, demo, train, trainp]
   clientAnalyticAccount: "Unknown"
   devMode: false


### PR DESCRIPTION
## Contexto

Tarea 70756. El chart gateaba `priorityClassName` a `appType == prod`; el resto de los loads (train/test/demo/int/…) caían al `globalDefault` (`default-priority`, `preemptionPolicy: Never`) y **no podían reclamar el `memory-buffer`** (DaemonSet 2Gi/nodo, `buffer-priority` -100) cuando su zona estaba apretada → pod CNPG `Pending`.

## Cambio

Nuevo helper `adhoc-odoo.priorityClassName` que resuelve la clase desde `appType`:

- `<appType>-priority` para los pods app (odoo, reverseProxy, waitPg).
- `<appType>-db-priority` para el pg (un escalón sobre el Odoo del mismo tier → puede despejarlo si necesita el slot; el Odoo es stateless, fácil de recolocar).
- **Fallback**: un `appType` fuera de `adhoc.priorityTiers` (nueva key en values) cae a `default-priority` → schedulea normal en vez de quedar `Pending` (una PriorityClass inexistente vuelve el pod no-scheduleable).

Reemplaza el gate `appType == prod` en `pgcluster.yaml`, `odoo/deployment.yaml`, `reverseProxy/deploy.yaml` y `cnpg/waitPg.yaml`.

## Dependencia

Requiere las PriorityClass creadas en **ingadhoc/devops-cloud-infra#32** (esquema app+db por tier). **Aplicar Pulumi primero**; si el chart rollea antes, referencia clases que no existen.

## Rollout

Sin rolling forzado — los pods toman la clase nueva en su **rotación natural**.

## Version bump

No bumpeo la versión del chart: el cambio es backward-compat (`priorityTiers` viene con defaults). A confirmar en review si el flujo de release lo requiere igual.

## Test plan

`helm template` (con `cloudNativePG.enabled=true`):

| appType | app (odoo/revProxy) | pg |
|---|---|---|
| `test` | `test-priority` ×2 | `test-db-priority` |
| `prod` | `prod-priority` ×2 | `prod-db-priority` |
| `zzz` (desconocido) | `default-priority` | `default-priority` ← fallback |

pre-commit: yamllint + helm validate (lint + template) OK.
