### PR TITLE
fix: sacar el request de recursos del sidecar exporter (deja solo limits)

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -337,9 +337,6 @@ spec:
             - name: prom-odoo
               containerPort: 9101
           resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
             limits:
               cpu: 100m
               memory: 64Mi


### PR DESCRIPTION
Saca el bloque `requests` del sidecar `prometheus-exporter`, dejando solo `limits` (cpu 100m / mem 64Mi). El exporter (~19Mi reales) se apoya en la holgura del pod de Odoo.

Tarea 70602.