### PR TITLE
fix: request de memoria mínimo (8Mi) en el sidecar exporter

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -337,6 +337,9 @@ spec:
             - name: prom-odoo
               containerPort: 9101
           resources:
+            requests:
+              cpu: 10m
+              memory: 8Mi
             limits:
               cpu: 100m
               memory: 64Mi


### PR DESCRIPTION
Corrige el estado que dejó #106. Al sacar el bloque `requests` entero, como estas namespaces no tienen LimitRange, Kubernetes setea `request=limit` → el sidecar quedó reservando **64Mi** (más que los 32Mi originales, lo opuesto al objetivo).

Uso real del exporter: ~19Mi. Se fija un `request` chico (cpu 10m / mem **8Mi**) como piso mínimo sin sobre-reservar, y se mantiene el `limit` (100m / 64Mi) como cap. No se saca el limit: los limits son por-container y sin él el sidecar quedaría sin tope de memoria.

Tarea 70602.