### PR TITLE
fix: habilitar safe-to-evict en cluster CNPG de weblate

### DIFF
--- a/charts/weblate/templates/cnpg.yaml
+++ b/charts/weblate/templates/cnpg.yaml
@@ -18,10 +18,14 @@ metadata:
     app.kubernetes.io/name: {{ include "app-instance.fullname" . }}-pg
   annotations:
     cnpg.io/hibernation: "off"
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 spec:
   priorityClassName: prod-priority
   smartShutdownTimeout: 0
   logLevel: info
+  inheritedMetadata:
+    annotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   imageName: "ghcr.io/cloudnative-pg/postgresql:{{ .Values.cloudNativePG.version | default "15.0" }}"
   primaryUpdateStrategy: unsupervised
   enablePDB: false


### PR DESCRIPTION
## Problema

El cluster-autoscaler de `adhocprod` emite repetidamente `no.scale.down.node.pod.not.backed.by.controller` para `weblate-pg-1`, y por eso **no consolida** el nodo del pool `no-prod` que lo aloja (`gke-adhocprod-nodes-nubeadhoc-no-prod-...`).

Causa: los pods de CNPG cuelgan del `Cluster` CR (`postgresql.cnpg.io/v1`), que el cluster-autoscaler **no reconoce como controller válido** (solo ReplicaSet/StatefulSet/Job/DaemonSet/ReplicationController). Sin ese reconocimiento el CA nunca drena un nodo con un pod de CNPG encima → efecto trinquete que deja el nodo colgado.

## Cambio

Se agrega `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"` en:

- `spec.inheritedMetadata.annotations` → **fix funcional**: CNPG propaga ese annotation a los pods que crea, que es donde el CA lo lee, habilitando el desalojo.
- `metadata.annotations` del `Cluster` → paridad con la convención de la flota.

Replica exactamente el patrón ya vigente en el chart hermano `adhoc-odoo` (`charts/adhoc-odoo/templates/cnpg/pgcluster.yaml`).

## Trade-off

El cluster es `instances: 1`. Habilitar el desalojo implica que al consolidar, CNPG mata y recrea el pod (breve downtime mientras reprograma sobre un nodo de la misma zona; el PVC es zonal). Aceptable para una herramienta interna, y es el estándar con que ya corren las bases no-prod del chart `adhoc-odoo`.

## Test plan

- `helm template` renderiza el `Cluster` con ambos annotations. ✓
- pre-commit (yamllint + helm lint/template) pasa. ✓
- Post-deploy (`helm upgrade` de weblate, lo dispara un humano): verificar que el pod expone el annotation:
  ```
  kubectl get pod weblate-pg-1 -n weblate -o jsonpath='{.metadata.annotations.cluster-autoscaler\.kubernetes\.io/safe-to-evict}'
  ```