### PR TITLE
fix: adhoc-odoo — liveness que auto-recupera el mount gcsfuse muerto

### DIFF
--- a/charts/adhoc-odoo/changelog.md
+++ b/charts/adhoc-odoo/changelog.md
@@ -4,6 +4,14 @@
 
 Fixes:
 
+- Bases `fuse`: la `livenessProbe` de `adhoc-odoo` y del reverse proxy (`-nx`)
+  pasa de `tcpSocket:8069` a un `exec` que verifica el mount del filestore. Si el
+  sidecar gcsfuse muere, el mount queda colgado (`Errno 107`) pero Odoo sigue
+  escuchando en 8069, así que el pod quedaba "vivo pero roto" (`/web/image` y
+  adjuntos daban 500); ahora el kubelet reinicia el container y gcsfuse remonta
+  limpio. odoo: `os.stat` del mount + check de puerto; nginx: `[ -d mount ]`. Se
+  agrega además `readinessProbe` al nginx del `-nx` (`tcpSocket:9080`). Solo
+  afecta bases `fuse`; con valores por defecto el render no cambia (sin bump).
 - OWC (wakeup controller): los helpers `wakeupController.domain` y
   `wakeupController.enabled` ahora toleran que el sub-map
   `autoscaling.wakeupController` venga nil/ausente (caso típico: `helm upgrade

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -6,6 +6,7 @@
 {{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
 {{- $fullName := include "adhoc-odoo.serviceNameSuffix" . -}}
 {{- $svcHost := ternary (printf "%s-nginx" $fullName) (printf "%s-http" $fullName) .Values.ingress.reverseProxy.enabled -}}
+{{- $fusePath := printf "/home/odoo/data/filestore/%s" (ternary "odoo" .Release.Name .Values.cloudNativePG.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -225,13 +226,20 @@ spec:
             initialDelaySeconds: 1
             failureThreshold: 900 # 15 min
             periodSeconds: 1
-          # Check if the pod is halted and need to be restarted
+          # Check if the pod is halted and need to be restarted. Bases no-fuse → tcpSocket.
           livenessProbe:
-            # httpGet:
-            #   path: /web/login
-            #   port: 8069
+            {{- if eq .Values.storage.location "fuse" }}
+            # exec, no tcpSocket: con el mount gcsfuse muerto (Errno 107) Odoo sigue escuchando en
+            # 8069, así que el tcp no lo ve. os.stat del mount + check del puerto → fuerza restart.
+            exec:
+              command:
+                - python3
+                - -c
+                - "import os,socket; os.stat('{{ $fusePath }}'); socket.create_connection(('127.0.0.1', 8069), 3).close()"
+            {{- else }}
             tcpSocket:
               port: 8069
+            {{- end }}
             initialDelaySeconds: 2
             periodSeconds: 15
             timeoutSeconds: 5
@@ -283,7 +291,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           {{- if eq .Values.storage.location "fuse" }}
-          {{- $fusePath := printf "/home/odoo/data/filestore/%s" (ternary "odoo" .Release.Name .Values.cloudNativePG.enabled) }}
+          {{- /* $fusePath se define al top del template (reusado por la livenessProbe) */}}
           - name: gcs-fuse-csi-ephemeral
             readOnly: false
             mountPath: {{ $fusePath }}

--- a/charts/adhoc-odoo/templates/reverseProxy/deploy.yaml
+++ b/charts/adhoc-odoo/templates/reverseProxy/deploy.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.reverseProxy.enabled }}
+{{- $nxFusePath := printf "/mnt/filestore/%s" (ternary "odoo" .Release.Name .Values.cloudNativePG.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,6 +81,30 @@ spec:
             - name: http
               containerPort: 9080
               protocol: TCP
+          # Readiness: saca el pod del Service si nginx deja de aceptar conexiones en 9080.
+          readinessProbe:
+            tcpSocket:
+              port: 9080
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          {{- if eq .Values.storage.location "fuse" }}
+          # nginx sirve el filestore por sendfile; sin probe seguiría "vivo" con 5xx si el mount
+          # gcsfuse muere. [ -d ], no ls: listar el root del bucket con implicit-dirs cuelga.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - '[ -d "{{ $nxFusePath }}" ]'
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 8 # 2 min
+            successThreshold: 1
+          {{- end }}
           {{- if eq .Values.adhoc.appType "prod" }}
           resources:
             requests:


### PR DESCRIPTION
## Contexto

Ticket 122777 (lavacatuerta): base percibida como "lenta para todos". En realidad eran **errores 500** en cada request al filestore (`/web/image`, imágenes de producto, adjuntos).

**Causa raíz:** el sidecar `gke-gcsfuse-sidecar` fue OOMKilled → el mount del filestore quedó colgado (`OSError [Errno 107] Transport endpoint is not connected`). El sidecar reinició solo, pero el container `adhoc-odoo` **no** reiniciaba porque su `livenessProbe` era `tcpSocket:8069`: Odoo sigue escuchando en 8069 aunque el filestore esté muerto → pod "vivo y roto" por horas. El reverse proxy (`-nx`) tenía el mismo agujero y sin ninguna probe.

## Cambio

- **odoo `livenessProbe`:** de `tcpSocket:8069` a `exec` = `os.stat(mount)` + chequeo del puerto 8069 (superconjunto del check anterior: falla si el puerto está caído **o** si el mount murió).
- **`-nx` `livenessProbe`:** `sh -c '[ -d "mount" ]'` (statea el root; **no** `ls`, que cuelga listando el root del bucket con `implicit-dirs` y reiniciaría pods sanos).
- **`-nx` `readinessProbe`:** nueva, `tcpSocket:9080` — saca el pod del Service si nginx deja de aceptar conexiones.
- **Guard por `storage.location=fuse`.** Las bases de upgrade (old/new/int) no son fuse, así que quedan con `tcpSocket` sin necesidad de un check extra por `appType`.
- **Sin bump de versión.** Con valores por defecto (`storage.location=attachment_s3`, `ingress.reverseProxy.enabled=false`) el render no cambia — verificado con diff. La nota queda en el changelog bajo `0.3.4`.

## Test plan

- `helm lint` + `helm template` OK. Matriz: odoo prod fuse → `exec`; odoo no-fuse → `tcpSocket`; `-nx` fuse → liveness `[ -d ]` + readiness; `-nx` no-fuse → solo readiness.
- **Retrocompat:** diff del render con valores por defecto (main vs branch) → sin diferencias funcionales (solo comentarios YAML, que k8s ignora).
- Tabla de verdad del `exec` en vivo (pod prod sano): mount OK + puerto OK → 0; puerto caído → ≠0; mount no stat-able → ≠0.
- Verificado: `python3` resuelve en exec sin shell; `[ -d mount ]` instantáneo (0.00s) en mount sano; readiness `9080` coincide con el `targetPort: http`/`controllerPort` del nginx.