### PR TITLE
refactor: derivar exporterSidecar de la versión de imagen (>= 18.0 y minor >= 20260714)

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -64,16 +64,24 @@ Get odoo minor version.
 {{- end }}
 
 {{- /*
+Odoo image minor version as a YYYYMMDD string, with a dateless (dev) tag assumed current (today).
+Pipe through `| int` at the call site. Keeps version gating consistent across templates.
+*/}}
+{{- define "adhoc-odoo.odoo-effective-minor-version" -}}
+{{- $minorRaw := include "adhoc-odoo.odoo-minor-version" . | trim -}}
+{{- ternary $minorRaw (now | date "20060102") (regexMatch "^[0-9]{8}$" $minorRaw) -}}
+{{- end }}
+
+{{- /*
 Whether the out-of-band Prometheus exporter sidecar should run. Derived from the Odoo image
 version instead of a static value: the sidecar only makes sense on images that ship the
 multiprocess-aware saas_prometheus module (Odoo >= 18.0 and image minor >= 20260714). Older
-images fall back to scraping the in-process controller on :8069. A dateless (dev) tag is
-assumed current (today). Returns "true" when enabled, empty otherwise.
+images fall back to scraping the in-process controller on :8069. Returns "true" when enabled,
+empty otherwise.
 */}}
 {{- define "adhoc-odoo.exporterSidecarEnabled" -}}
 {{- $major := include "adhoc-odoo.odoo-version" . | replace "." "" | int -}}
-{{- $minorRaw := include "adhoc-odoo.odoo-minor-version" . | trim -}}
-{{- $effectiveMinor := int (ternary $minorRaw (now | date "20060102") (regexMatch "^[0-9]{8}$" $minorRaw)) -}}
+{{- $effectiveMinor := include "adhoc-odoo.odoo-effective-minor-version" . | int -}}
 {{- if and (ge $major 180) (ge $effectiveMinor 20260714) -}}
 true
 {{- end -}}

--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -63,6 +63,22 @@ Get odoo minor version.
 {{- printf "%s" (regexReplaceAll "^[0-9][0-9]\\.[0-9]\\.([0-9][0-9][0-9][0-9])\\.([0-9][0-9])\\.([0-9][0-9]).*" .Values.image.tag "$1$2$3") }}
 {{- end }}
 
+{{- /*
+Whether the out-of-band Prometheus exporter sidecar should run. Derived from the Odoo image
+version instead of a static value: the sidecar only makes sense on images that ship the
+multiprocess-aware saas_prometheus module (Odoo >= 18.0 and image minor >= 20260714). Older
+images fall back to scraping the in-process controller on :8069. A dateless (dev) tag is
+assumed current (today). Returns "true" when enabled, empty otherwise.
+*/}}
+{{- define "adhoc-odoo.exporterSidecarEnabled" -}}
+{{- $major := include "adhoc-odoo.odoo-version" . | replace "." "" | int -}}
+{{- $minorRaw := include "adhoc-odoo.odoo-minor-version" . | trim -}}
+{{- $effectiveMinor := int (ternary $minorRaw (now | date "20060102") (regexMatch "^[0-9]{8}$" $minorRaw)) -}}
+{{- if and (ge $major 180) (ge $effectiveMinor 20260714) -}}
+true
+{{- end -}}
+{{- end }}
+
 
 {{- /*
 Common labels

--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -65,7 +65,9 @@ Get odoo minor version.
 
 {{- /*
 Odoo image minor version as a YYYYMMDD string, with a dateless (dev) tag assumed current (today).
-Pipe through `| int` at the call site. Keeps version gating consistent across templates.
+Pipe through `| int` at the call site. Used by the exporter-sidecar and PodMonitor gates so a
+dateless/dev tag is treated as current; other version gates in the chart still read
+odoo-minor-version directly (dateless -> 0).
 */}}
 {{- define "adhoc-odoo.odoo-effective-minor-version" -}}
 {{- $minorRaw := include "adhoc-odoo.odoo-minor-version" . | trim -}}

--- a/charts/adhoc-odoo/templates/monitoringCommon.yaml
+++ b/charts/adhoc-odoo/templates/monitoringCommon.yaml
@@ -25,7 +25,7 @@ spec:
           protocol: TCP
       {{- end }}
       {{- if .Values.odoo.monitoring.enabled }}
-        {{- if .Values.odoo.monitoring.exporterSidecar }}
+        {{- if eq (include "adhoc-odoo.exporterSidecarEnabled" .) "true" }}
         - port: 9101
           protocol: TCP
         {{- else }}

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -324,12 +324,12 @@ spec:
           - name: session-folder-ro
             mountPath: /home/odoo/data/sessions
             readOnly: true
-          {{- if and .Values.odoo.monitoring.enabled .Values.odoo.monitoring.exporterSidecar }}
+          {{- if and .Values.odoo.monitoring.enabled (eq (include "adhoc-odoo.exporterSidecarEnabled" .) "true") }}
           # Shared with the prometheus-exporter sidecar; the module writes multiprocess metric files here.
           - name: prometheus-multiproc
             mountPath: /tmp/prometheus_client
           {{- end }}
-        {{- if and .Values.odoo.monitoring.enabled .Values.odoo.monitoring.exporterSidecar }}
+        {{- if and .Values.odoo.monitoring.enabled (eq (include "adhoc-odoo.exporterSidecarEnabled" .) "true") }}
         # Out-of-band metrics exporter: serves /metrics from the shared multiprocess dir so scrapes
         # survive Odoo worker-pool exhaustion. Image from values (monitoring.exporterRepository/Tag);
         # source at devops-ops-tools/prometheusOdooExporter.
@@ -469,7 +469,7 @@ spec:
       {{- end }}
       - name: session-folder-ro
         emptyDir: {}
-      {{- if and .Values.odoo.monitoring.enabled .Values.odoo.monitoring.exporterSidecar }}
+      {{- if and .Values.odoo.monitoring.enabled (eq (include "adhoc-odoo.exporterSidecarEnabled" .) "true") }}
       # Volume shared with the exporter sidecar for prometheus_client multiproc files (tiny mmap files).
       - name: prometheus-multiproc
         emptyDir: {}

--- a/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
+++ b/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       {{- include "adhoc-odoo.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
-  {{- if .Values.odoo.monitoring.exporterSidecar }}
+  {{- if eq (include "adhoc-odoo.exporterSidecarEnabled" .) "true" }}
   - port: prom-odoo
     path: /metrics
     interval: 60s

--- a/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
+++ b/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
@@ -1,4 +1,4 @@
-{{- $minorVersion := include "adhoc-odoo.odoo-minor-version" . | int -}}
+{{- $minorVersion := include "adhoc-odoo.odoo-effective-minor-version" . | int -}}
 {{- $odooVersion := include "adhoc-odoo.odoo-version" . | replace "." "" | int -}}
 {{- if and .Values.odoo.monitoring.enabled (ge $odooVersion 180) (ge $minorVersion 20251121) }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/adhoc-odoo/templates/odooEnvs.yaml
+++ b/charts/adhoc-odoo/templates/odooEnvs.yaml
@@ -179,11 +179,9 @@ data:
   LITELLM_LOG: "CRITICAL"
   {{- /* Multiprocess mode lets the exporter sidecar read metrics from files. In prefork (workers>0)
          every image creates the dir, so it's always safe. In threaded mode (workers=0) the dir is
-         only created on images >= 2026-06-24; gate on the image minor version to avoid crashing
-         older images. Tags carry a date by design; a dateless (dev) tag is assumed current (today). */}}
-  {{- $minorRaw := include "adhoc-odoo.odoo-minor-version" . | trim -}}
-  {{- $effectiveMinor := int (ternary $minorRaw (now | date "20060102") (regexMatch "^[0-9]{8}$" $minorRaw)) -}}
-  {{- if and .Values.odoo.monitoring.enabled (or (gt $workers 0) (and .Values.odoo.monitoring.exporterSidecar (ge $effectiveMinor 20260624))) }}
+         only created on images new enough to ship the sidecar, so reuse exporterSidecarEnabled
+         (Odoo >= 18.0 and minor >= 20260714) to avoid crashing older images. */}}
+  {{- if and .Values.odoo.monitoring.enabled (or (gt $workers 0) (eq (include "adhoc-odoo.exporterSidecarEnabled" .) "true")) }}
   PROMETHEUS_MULTIPROC_DIR: "/tmp/prometheus_client"
   {{- end }}
   KWKHTMLTOPDF_SERVER_URL: {{ .Values.odoo.kwkhtmltopdfServerUrl | quote }}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -388,11 +388,12 @@ odoo:
     # example2: "no"
   monitoring:
     enabled: false
-    # Out-of-band metrics exporter sidecar (only takes effect when monitoring.enabled=true).
-    # When true (default), Prometheus scrapes the sidecar (:9101), which reads the multiprocess
-    # dir, so metrics survive Odoo worker-pool exhaustion. Set false to fall back to scraping the
-    # in-process controller (:8069) — the old behavior.
-    exporterSidecar: true
+    # Out-of-band metrics exporter sidecar: Prometheus scrapes the sidecar (:9101), which reads the
+    # multiprocess dir, so metrics survive Odoo worker-pool exhaustion. Enablement is NOT a static
+    # value: it's derived from the Odoo image version (helper adhoc-odoo.exporterSidecarEnabled) —
+    # used on images >= 18.0 with minor >= 20260714 (which ship the multiprocess-aware module), and
+    # falls back to scraping the in-process controller (:8069) on older images. Only takes effect
+    # when monitoring.enabled=true.
     # Built by the prometheusOdooExporter GitHub Action (pushed to docker.io/adhoc/ops-tools, pulled
     # via this mirror). Pin a dated tag (prometheusOdooExporter-<YYYY.MM.DD>.<run>) in prod; -latest
     # is fine for testing. Keep the exporter's prometheus_client aligned with the Odoo image.

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -388,15 +388,6 @@ odoo:
     # example2: "no"
   monitoring:
     enabled: false
-    # Out-of-band metrics exporter sidecar: Prometheus scrapes the sidecar (:9101), which reads the
-    # multiprocess dir, so metrics survive Odoo worker-pool exhaustion. Enablement is NOT a static
-    # value: it's derived from the Odoo image version (helper adhoc-odoo.exporterSidecarEnabled) —
-    # used on images >= 18.0 with minor >= 20260714 (which ship the multiprocess-aware module), and
-    # falls back to scraping the in-process controller (:8069) on older images. Only takes effect
-    # when monitoring.enabled=true.
-    # Built by the prometheusOdooExporter GitHub Action (pushed to docker.io/adhoc/ops-tools, pulled
-    # via this mirror). Pin a dated tag (prometheusOdooExporter-<YYYY.MM.DD>.<run>) in prod; -latest
-    # is fine for testing. Keep the exporter's prometheus_client aligned with the Odoo image.
     exporterRepository: dockerhub.adhoc.inc/adhoc/ops-tools
     exporterTag: "prometheusOdooExporter-latest"
 


### PR DESCRIPTION
## Qué

`exporterSidecar` deja de ser un value estático (`default: true`) y pasa a derivarse de la versión de la imagen de Odoo, vía el nuevo helper `adhoc-odoo.exporterSidecarEnabled`.

## Por qué

El sidecar exporter solo funciona bien con imágenes que traen el módulo `saas_prometheus` multiproc-aware (multiproc en threading + cron de métricas DB). Como value estático default-true, se habilitaba también sobre imágenes viejas que no lo soportan. Derivarlo de la versión es más consistente con el comportamiento real.

## Regla

Sidecar habilitado ⟺ imagen Odoo `>= 18.0` **y** minor `>= 20260714`. Imágenes más viejas → fallback a scrapear el controller in-process (`:8069`). Tag dateless (dev) se asume actual (hoy).

Además se unifica el gate de `PROMETHEUS_MULTIPROC_DIR` con el mismo helper (antes gateado a mano en `20260624`, ahora redundante). En prefork se sigue seteando el dir siempre (retrocompat controller-scrape).

## Validación (`helm template`, `monitoring.enabled=true`)

| tag | workers | sidecar | multiproc-env |
|---|---|---|---|
| 19.0.2026.07.14 | 0 | ✅ | ✅ |
| 19.0.2026.07.13 | 0 | ❌ | ❌ |
| 18.0.2026.07.14 | 0 | ✅ | ✅ |
| 17.0.2026.08.01 | 0 | ❌ | ❌ |
| 19.0 (dev) | 0 | ✅ | ✅ |
| 19.0.2026.06.24 | 3 (prefork) | ❌ | ✅ |

Sin bump de versión (backward-compatible: ningún consumer externo seteaba `exporterSidecar`, helm ignora el value removido). `helm lint` + pre-commit (yamllint + helm validate) OK.
