### PR TITLE
fix: setear X-Forwarded-Host en VirtualService Istio para url_root https

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
@@ -46,6 +46,8 @@ spec:
       headers:
         request:
           set:
+            {{- /* activa ProxyFix de Odoo (gate X-Forwarded-Host) para url_root https bajo Istio */}}
+            x-forwarded-host: '%REQ(:AUTHORITY)%'
             {{- if ne .Values.ingress.reverseProxy.inactive.mode "" }}
             x-maintenance-mode: {{ .Values.ingress.reverseProxy.inactive.mode | quote }}
             x-maintenance-eta:  {{ .Values.ingress.reverseProxy.inactive.eta | default "" | quote }}
@@ -134,6 +136,8 @@ spec:
       headers:
         request:
           set:
+            {{- /* activa ProxyFix de Odoo (gate X-Forwarded-Host) para url_root https bajo Istio */}}
+            x-forwarded-host: '%REQ(:AUTHORITY)%'
             {{- if ne .Values.ingress.reverseProxy.inactive.mode "" }}
             x-maintenance-mode: {{ .Values.ingress.reverseProxy.inactive.mode | quote }}
             x-maintenance-eta:  {{ .Values.ingress.reverseProxy.inactive.eta | default "" | quote }}


### PR DESCRIPTION
## Problema

En ambientes SaaS servidos por Istio **sin** reverseProxy/OEP (ej. instancias `new-*`, `int-*`, `test-*`), Odoo genera URLs absolutas en **http** en vez de https. Se reporta visible en el login OAuth Office365: el `redirect_uri` sale `http://...`, con lo que el proveedor rechaza / rompe el flujo.

## Causa raíz

Odoo corre con `proxy_mode=True`, pero en `odoo/http.py` el `ProxyFix` (lo único que hace que honre `X-Forwarded-Proto`) se aplica **solo si además llega `X-Forwarded-Host`**:

```python
if odoo.tools.config['proxy_mode'] and environ.get("HTTP_X_FORWARDED_HOST"):
    ProxyFix(fake_app)(environ, fake_start_response)
```

Istio **no** agrega `X-Forwarded-Host` — Envoy setea `X-Forwarded-For/Proto/Port` pero preserva el `Host`/authority. Sin ese gate, Odoo ignora el `X-Forwarded-Proto: https` que Istio **sí** manda y deriva `url_root` del socket del pod, que es http (TLS termina en el gateway).

El OEP (`odooEdgeProxy`) y el viejo nginx-ingress **sí** setean `X-Forwarded-Host`, por eso trainp/prod (con reverseProxy) nunca tuvieron el problema.

## Fix

Setear `x-forwarded-host` en los dos `VirtualService` del chart (shared y custom-domain) usando el formatter dinámico de Envoy `%REQ(:AUTHORITY)%`:

- No hardcodea el host → sirve para el host shared y para `altHosts` (custom domains).
- Se apoya en el `X-Forwarded-Proto: https` nativo de Istio; no hace falta forzar el proto.
- Inofensivo cuando el OEP está activo: su `map` de nginx usa el `X-Forwarded-Host` entrante.

## Verificación

- `helm template` + pre-commit (yamllint + helm lint) OK.
- En vivo (cluster01, tenant sin reverseProxy): patcheando la VS con `x-forwarded-host`, el `redirect_uri` de OAuth pasa de **http → https**. Sin el header vuelve a http. Confirmado que con solo el host (sin tocar el proto) ya alcanza.

## Notas

- Cambio backward-compat, sin bump de versión de chart.
- Requiere `helm upgrade` de los tenants para tomar efecto.