### PR TITLE
feat: OWC chart 0.4.6 — waiting pages por tier + i18n

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.4.5
+version: 0.4.6
 
-appVersion: "odooWakeupController-2026.07.10.36"
+appVersion: "odooWakeupController-2026.07.16.39"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.07.10.36
+  tag: odooWakeupController-2026.07.16.39
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bump del chart `adhoc-wakeup-controller` **0.4.5 → 0.4.6**, apuntando a la imagen `odooWakeupController-2026.07.16.39`.

## Qué trae la imagen nueva

- Waiting pages **por tier** (`www/tiers/<tier>.html`) con fallback a `index.html` (new/demo/test con diseño nuevo; old/int comparten new vía symlink; prod → default).
- **i18n data-driven** ES/EN vía `data-en` / `data-en-html` / `data-en-aria` (incluye aria-labels); runner genérico en `wait.js`.
- `preconnect` a `fonts.gstatic.com`.

Corresponde a los PRs `ingadhoc/devops-ops-tools#40` y `#41`.

## Validación

- Imagen equivalente probada en **cluster01** vía patch directo del OWC stable: la waiting page se sirve correcta por tier (headers del VS), assets 200, `wait.js` con el runner nuevo, y el controller opera normal (idle-detection + VS switch + KEDA). Ver rollout OK.

## Nota de rollout

Al mergear, la Action de GH Pages publica el chart `0.4.6`. Recién ahí `ingadhoc/devops-cloud-infra` puede referenciar `chart_version=0.4.6` (PR aparte, en draft) y un `pulumi up` hace el rollout permanente.