### PR TITLE
fix: bootstrap CNPG estable — echoar el existente en vez de re-derivarlo

### DIFF
--- a/charts/adhoc-odoo/templates/cnpg/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/cnpg/_helpers.tpl
@@ -13,3 +13,10 @@ Pg name sanitization.
 {{- $original = regexReplaceAll "^[0-9]+" $original "" }}
 {{- regexReplaceAll "[^a-z0-9-]" $original "" }}
 {{- end }}
+
+{{- /*
+CNPG Cluster object name (single source of truth for the lookup name).
+*/}}
+{{- define "cnpg.pgClusterName" -}}
+{{- printf "%s-pg" (include "cnpg.sanitizedPgName" .) }}
+{{- end }}

--- a/charts/adhoc-odoo/templates/cnpg/pg_restoreVolumenes.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/pg_restoreVolumenes.yaml
@@ -1,5 +1,5 @@
 {{- /* Restore source snapshot: only on initial creation, not on clusters that already exist. */}}
-{{- $existingCluster := (lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace (printf "%s-pg" (include "cnpg.sanitizedPgName" .))) }}
+{{- $existingCluster := (lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace (include "cnpg.pgClusterName" .)) }}
 {{- if and .Values.cloudNativePG.enabled .Values.cloudNativePG.restore.fromGCPSnapshot (not $existingCluster) }}
 
 # Class

--- a/charts/adhoc-odoo/templates/cnpg/pg_restoreVolumenes.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/pg_restoreVolumenes.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.cloudNativePG.enabled .Values.cloudNativePG.restore.fromGCPSnapshot }}
+{{- /* Restore source snapshot: only on initial creation, not on clusters that already exist. */}}
+{{- $existingCluster := (lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace (printf "%s-pg" (include "cnpg.sanitizedPgName" .))) }}
+{{- if and .Values.cloudNativePG.enabled .Values.cloudNativePG.restore.fromGCPSnapshot (not $existingCluster) }}
 
 # Class
 {{- $volumeSnapshotClass := default "gcp-r" .Values.cloudNativePG.restore.volumeSnapshotClass }}

--- a/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
@@ -251,7 +251,12 @@ spec:
     {{- end }}
     target: prefer-standby
 
-  {{- if .Values.cloudNativePG.restore.inTimeRecovery }}
+  {{- /* bootstrap is create-only: echo the live one on existing clusters, never re-derive it. */}}
+  {{- $existingCluster := (lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace (printf "%s-pg" (include "cnpg.sanitizedPgName" .))) }}
+  {{- if and $existingCluster $existingCluster.spec $existingCluster.spec.bootstrap }}
+  bootstrap:
+    {{- $existingCluster.spec.bootstrap | toYaml | nindent 4 }}
+  {{- else if .Values.cloudNativePG.restore.inTimeRecovery }}
   bootstrap:
     recovery:
       {{- if or .Values.cloudNativePG.restore.fromSnapshot .Values.cloudNativePG.restore.fromGCPSnapshot }}
@@ -306,7 +311,8 @@ spec:
             annotations:
               exposed-service: "true"
       {{- end }}
-  {{- if not .Values.cloudNativePG.restore.inTimeRecovery }}
+  {{- /* Manage roles on existing clusters or fresh non-restore installs. */}}
+  {{- if or $existingCluster (not .Values.cloudNativePG.restore.inTimeRecovery) }}
     roles:
     - name: odoo
       ensure: present

--- a/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/pgcluster.yaml
@@ -251,11 +251,13 @@ spec:
     {{- end }}
     target: prefer-standby
 
-  {{- /* bootstrap is create-only: echo the live one on existing clusters, never re-derive it. */}}
-  {{- $existingCluster := (lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace (printf "%s-pg" (include "cnpg.sanitizedPgName" .))) }}
-  {{- if and $existingCluster $existingCluster.spec $existingCluster.spec.bootstrap }}
+  {{- /* bootstrap is create-only: on existing clusters echo the live one (or omit if none), never re-derive it. */}}
+  {{- $existingCluster := (lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace (include "cnpg.pgClusterName" .)) }}
+  {{- if $existingCluster }}
+  {{- if and $existingCluster.spec $existingCluster.spec.bootstrap }}
   bootstrap:
     {{- $existingCluster.spec.bootstrap | toYaml | nindent 4 }}
+  {{- end }}
   {{- else if .Values.cloudNativePG.restore.inTimeRecovery }}
   bootstrap:
     recovery:


### PR DESCRIPTION
## Qué

En clusters CNPG **ya creados**, el chart deja de re-derivar los recursos de "creación por restore" y los deja estables:

1. **bootstrap**: echoa el `spec.bootstrap` vivo (vía `lookup`) en vez de re-derivarlo desde `restore.inTimeRecovery`.
2. **managed.roles**: desacoplado de `inTimeRecovery` (un cluster restaurado también gestiona sus roles).
3. **pg_restoreVolumenes**: el `VolumeSnapshot`/`VolumeSnapshotContent` fuente del restore solo se crea en la creación inicial, no en clusters existentes (evita churn de snapshots stale por deploy).

En la **creación** (cluster inexistente, `lookup` vacío) el comportamiento es idéntico al actual.

## Por qué

`bootstrap` es **create-only** en CNPG: solo se usa al crear el cluster; después el operador lo ignora, pero el webhook valida "only one bootstrap method" en **cada write**. Re-derivarlo en cada deploy causaba el flip `recovery`↔`initdb` que, bajo server-side apply + `--reuse-values`, dejaba `initdb` + `recovery` juntos → webhook rechaza → release de Helm trabada (incidente en cluster02). Con el echo, un cluster ya creado mantiene su bootstrap estable pase lo que pase con los flags de restore → nunca hay flip → nunca el wedge. Mismo principio create-only para los otros dos recursos.

## Validación

**Render (`--dry-run=server` contra un cluster real, sin blast radius).** Con `inTimeRecovery=latest` (lo que arrastraría un reuse-deploy):

| | chart viejo | chart nuevo |
|---|---|---|
| `spec.bootstrap` | `recovery` ← el flip que rompió | `initdb` (echoado) ✅ |
| `managed.roles` | no renderiza | `odoo` presente ✅ |
| VolumeSnapshot fuente (cluster existente) | se crea (churn) | 0 recursos ✅ |

**Apply real (end-to-end) sobre una base de restore real** (`test-grittiagrimensura`, cluster01), en el escenario que rompía (`inTimeRecovery=latest`): `helm upgrade` → **`deployed`, EXIT 0**; bootstrap vivo siguió `initdb` (no flip), `managed.roles` gestionó `odoo`, pods sin reinicio (sin disrupción), y no se creó VolumeSnapshot stale. Con el chart viejo este mismo apply habría trabado la release.

> `lookup` devuelve vacío en `helm template` / `--dry-run=client`; en upgrades reales y `--dry-run=server` consulta el cluster vivo (como corre el flujo SaaS).

## Contexto

Spec + validación del approach en `ingadhoc/devops-project#21` (`specs/10_draft/cnpg-bootstrap-estable-post-restore.md`).

"B" (que `--reuse-values` no revivan los flags de restore en `saas_k8s`) queda como hardening **opcional** fuera de este PR: con estos cambios el wedge y el churn ya no ocurren.

## Notas

- Sin bump de `Chart.yaml` (cambio backward-compat, interfaz de values intacta) — a criterio del publish/deploy del chart.
