### PR TITLE
[FIX] adhoc-odoo — limitar retries del VS de dominio custom al cold-start de KEDA sin OWC

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
@@ -59,6 +59,14 @@ spec:
             host: {{ $srvHttp }}
             port:
               number: {{ $srvPort }}
+      {{- if and $isKedaEnabled (not $isWakeupEnabled) }}
+      # Ver mismo bloque en el VS "*-custom": solo cold-start de KEDA sin
+      # wakeup controller, seguro porque todavía no hay backend real.
+      retries:
+        attempts: 10
+        perTryTimeout: 5s
+        retryOn: gateway-error,connect-failure,refused-stream
+      {{- end }}
       {{- if gt $usewebsocket 0 }}
     - match:
         - uri:
@@ -149,10 +157,17 @@ spec:
             host: {{ $srvHttp }}
             port:
               number: {{ $srvPort }}
+      {{- if and $isKedaEnabled (not $isWakeupEnabled) }}
+      # Solo para KEDA sin wakeup controller: durante el cold-start el
+      # interceptor de KEDA sostiene la conexión sin haber llegado a un backend
+      # real, así que reintentar acá no duplica nada (gateway-error = sigue
+      # dormido). Sin esta condición, el mismo bloque reintenta sobre backends
+      # ya despiertos y duplica cualquier acción no idempotente en curso.
       retries:
         attempts: 10
         perTryTimeout: 5s
         retryOn: gateway-error,connect-failure,refused-stream
+      {{- end }}
       {{- if gt $usewebsocket 0 }}
     - match:
         - uri:


### PR DESCRIPTION
## Resumen

El bloque `retries` (`attempts: 10`, `perTryTimeout: 5s`, `retryOn: gateway-error,connect-failure,refused-stream`) se aplicaba a toda base con dominio propio (`*-custom`), sin condicionar por modo de autoscaling. Esta ruta lleva también POSTs no idempotentes (`call_kw`, `call_button`) con side effects reales (mail, writes). Con `perTryTimeout: 5s` aplicando incluso al intento inicial y `gateway-error` en `retryOn`, cualquier acción que tarde más de 5s hace que Envoy abandone ese intento y dispare uno nuevo — el backend no se entera del abandono y termina de procesar el intento viejo igual, duplicando el efecto una vez por reintento (hasta 10 veces).

## Cómo se detectó

Reproducido en un cliente en producción (base always-on, sin KEDA): una acción de envío de reporte tardaba ~5-6s por intento. Se observaron hasta 8 ejecuciones reales del mismo envío de mail para un solo click, con la ventana del cliente colgada hasta el 504 final. Confirmado con A/B en vivo sobre el mismo request lento (~25s): duplica en el dominio custom, un solo intento y 200 OK en el dominio `.adhoc.inc` (`*-shared`) — la única diferencia de config entre ambos hosts era ese bloque `retries`.

## Por qué existe el bloque (contexto del reviewer)

Se agregó para el cold-start de KEDA sin wakeup controller: cuando KEDA escala desde cero y tarda >20s en levantar, este retry (5s × 10 = 50s) da margen antes de mostrar un 503. Números ajustados a propósito: cada intento no tiene sentido por más de ~30s (KEDA corta la conexión antes) y el total no tiene sentido por más de ~100s (Cloudflare corta ahí). Ese diseño es correcto en ese contexto puntual: durante el cold-start el interceptor de KEDA sostiene la conexión sin haber llegado a un backend real, así que reintentar (incluso sobre `gateway-error`) no duplica nada.

## Fix

El bloque `retries` queda condicionado a la misma combinación que ya usa el template para rutear por el interceptor de KEDA (`isKedaEnabled && !isWakeupEnabled`), en **los dos** VirtualService que genera este template: `*-shared` (dominio interno `.adhoc.inc`) y `*-custom` (dominio propio del cliente). La primera versión de este PR solo lo condicionaba en `*-custom`; sin la misma condición en `*-shared`, una base KEDA-sin-OWC accedida por su dominio interno durante un cold-start se quedaba sin la ventana de gracia. Valores originales sin modificar. El resto de las bases (prod always-on + KEDA+wakeupController, que ya tiene su propia waiting page) queda sin `retries` en ninguno de los dos VS — igual que `*-shared` se comportaba antes de este incidente.

```yaml
{{- if and $isKedaEnabled (not $isWakeupEnabled) }}
retries:
  attempts: 10
  perTryTimeout: 5s
  retryOn: gateway-error,connect-failure,refused-stream
{{- end }}
```

## Test plan

- [x] `helm lint charts/adhoc-odoo`
- [x] `helm template` en los 3 escenarios (KEDA sin wakeupController / KEDA+wakeupController / sin KEDA), confirmando `retries` presente en shared+custom solo en el primero
- [ ] Confirmar en cluster que el cold-start de las bases KEDA-sin-OWC sigue tolerando el wake-up sin 503 prematuro, por ambos dominios (interno y custom)
- [ ] Confirmar que una base always-on con dominio propio ya no duplica una acción lenta no idempotente