### PR TITLE
fix: nombre determinístico del snapshot de restore CNPG (elimina race de `now`)

### DIFF
--- a/charts/adhoc-odoo/templates/cnpg/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/cnpg/_helpers.tpl
@@ -1,8 +1,9 @@
 {{- /*
 Expand the name of the chart.
 */}}
+{{- /* Deterministic (no `now`): se evalúa por separado en pg_restoreVolumenes.yaml y pgcluster.yaml; releaseName+namespace es único por release aun con 2 CNPG en el mismo ns. */}}
 {{- define "cnpg.targetBkp" -}}
-{{- now | date "20060102150405" }}
+{{- printf "%s-%s" .Release.Name .Release.Namespace | sha256sum | trunc 12 }}
 {{- end }}
 
 {{- /*


### PR DESCRIPTION
## Problema

Restores CNPG desde snapshot quedan colgados: helm timeout en el post-install (`wait-pg` Job never ready) y el CNPG **nunca crea la primera instancia** de postgres.

Causa raíz: el helper `cnpg.targetBkp` generaba el nombre del VolumeSnapshot de restore con `now | date "20060102150405"`, y se evaluaba **por separado** en dos templates:

- `templates/cnpg/pg_restoreVolumenes.yaml` — crea el `VolumeSnapshot` (`<ts>-vs`).
- `templates/cnpg/pgcluster.yaml:267` — lo referencia en `bootstrap.recovery.volumeSnapshots.storage.name`.

`now` en Helm se evalúa en cada `include`. Si el render cruza el tick de segundo entre los dos templates, los nombres quedan desfasados 1s: el VolumeSnapshot se crea como `<ts>-vs` pero el bootstrap del Cluster apunta a `<ts-1>-vs`. El operador CNPG entra en loop infinito de verificación:

```
Volume snapshots verification failed, retrying
  status.errors: [{objectName: "<ts-1>-vs", message: "the volume doesn't exist"}]
```

→ nunca crea PVC ni instancia → `wait-pg` cuelga → helm post-install timeout.

### Evidencia (cluster01, 2026-07-21)

| Namespace | Bootstrap busca | VolumeSnapshot real (`readyToUse=true`) |
|---|---|---|
| `test-inquimex-21-07-1` | `20260721122953-vs` | `20260721122954-vs` |
| `train-puntodeimpacto-21-07-1` | `20260721125914-vs` | `20260721125915-vs` |

Desfase de exactamente 1s en ambos. El timestamp del release helm (`12:29:53` / `12:59:14`) coincide con la referencia del bootstrap = la primera de las dos evaluaciones de `now`. 2/793 clusters afectados (ventana chica pero reproducible).

## Fix

Reemplazo `now` por un token **determinístico** derivado de `.Release.Name` + `.Release.Namespace`. Ambos templates renderizan siempre el mismo nombre, sin depender del reloj.

Se incluye el **release name** además del namespace porque el `VolumeSnapshot` se nombra `<token>-vs` **sin prefijo de namespace** — con namespace solo, 2 clusters CNPG en el mismo ns colisionarían el VS. Además alinea con el resto del chart, que ya deriva la identidad CNPG del release name (`cnpg.pgClusterName` / `cnpg.sanitizedPgName`).

Solo afecta **restores nuevos**: la rama está gateada por `not $existingCluster`, los clusters existentes no se re-derivan (ver #114). Backward-compatible.

## Verificación

- `helm lint` ✅ · pre-commit (`helm validate charts`) ✅
- Render con `inTimeRecovery=latest` + `fromGCPSnapshot`:
  - **Determinismo** — VolumeSnapshot creado == bootstrap.recovery: `42ded288b19d-vs` == `42ded288b19d-vs` ✅
  - **2 releases distintos, mismo ns → tokens distintos**: `8386835430f8` vs `6ac61db1b176` ✅
  - **Estable** entre renders del mismo release+ns ✅

## Notas para el review

- Alternativa considerada: pasar el nombre computado una sola vez desde el código SaaS (`odoo-saas`) vía value. Más definitivo pero cross-repo; este fix es chart-only y resuelve el race por completo.
- **Versión del chart**: no bumpeé `0.3.4` (cambio backward-compat). Si la publicación a gh-pages requiere bump, avisar y lo agrego.
- Observación aparte (no incluida acá): `pgcluster.yaml:273` `walStorage.name` usa `.Values.cloudNativePG.restore.fromSnapshot` directo — si `separateWAL` + solo `fromGCPSnapshot`, renderiza `-wal` sin prefijo. Path aparentemente no ejercitado en restores GCP; lo dejo como follow-up.