### PR TITLE
fix: revertir la livenessProbe exec de #110 en bases fuse (vuelve a tcpSocket)

### DIFF
--- a/charts/adhoc-odoo/changelog.md
+++ b/charts/adhoc-odoo/changelog.md
@@ -4,14 +4,13 @@
 
 Fixes:
 
-- Bases `fuse`: la `livenessProbe` de `adhoc-odoo` y del reverse proxy (`-nx`)
-  pasa de `tcpSocket:8069` a un `exec` que verifica el mount del filestore. Si el
-  sidecar gcsfuse muere, el mount queda colgado (`Errno 107`) pero Odoo sigue
-  escuchando en 8069, así que el pod quedaba "vivo pero roto" (`/web/image` y
-  adjuntos daban 500); ahora el kubelet reinicia el container y gcsfuse remonta
-  limpio. odoo: `os.stat` del mount + check de puerto; nginx: `[ -d mount ]`. Se
-  agrega además `readinessProbe` al nginx del `-nx` (`tcpSocket:9080`). Solo
-  afecta bases `fuse`; con valores por defecto el render no cambia (sin bump).
+- Bases `fuse`: se revierte la `livenessProbe` exec de #110 (`adhoc-odoo` y `-nx`)
+  y se vuelve a `tcpSocket:8069`. La reproducción mostró que un restart de container
+  no re-monta el gcsfuse (mount pod-scoped): el exec no auto-recuperaba y podía
+  crashloopear (`StartError` en el mount anidado `checklist`). La detección y
+  recuperación pasan a una alerta de Prometheus + un controller que recrea el pod.
+  (También se revierte el `readinessProbe:9080` que #110 sumó al `-nx`; es
+  ortogonal al mount y se puede re-agregar aparte si se quiere.)
 - OWC (wakeup controller): los helpers `wakeupController.domain` y
   `wakeupController.enabled` ahora toleran que el sub-map
   `autoscaling.wakeupController` venga nil/ausente (caso típico: `helm upgrade

--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -6,7 +6,6 @@
 {{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
 {{- $fullName := include "adhoc-odoo.serviceNameSuffix" . -}}
 {{- $svcHost := ternary (printf "%s-nginx" $fullName) (printf "%s-http" $fullName) .Values.ingress.reverseProxy.enabled -}}
-{{- $fusePath := printf "/home/odoo/data/filestore/%s" (ternary "odoo" .Release.Name .Values.cloudNativePG.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -226,20 +225,13 @@ spec:
             initialDelaySeconds: 1
             failureThreshold: 900 # 15 min
             periodSeconds: 1
-          # Check if the pod is halted and need to be restarted. Bases no-fuse → tcpSocket.
+          # Check if the pod is halted and need to be restarted
           livenessProbe:
-            {{- if eq .Values.storage.location "fuse" }}
-            # exec, no tcpSocket: con el mount gcsfuse muerto (Errno 107) Odoo sigue escuchando en
-            # 8069, así que el tcp no lo ve. os.stat del mount + check del puerto → fuerza restart.
-            exec:
-              command:
-                - python3
-                - -c
-                - "import os,socket; os.stat('{{ $fusePath }}'); socket.create_connection(('127.0.0.1', 8069), 3).close()"
-            {{- else }}
+            # httpGet:
+            #   path: /web/login
+            #   port: 8069
             tcpSocket:
               port: 8069
-            {{- end }}
             initialDelaySeconds: 2
             periodSeconds: 15
             timeoutSeconds: 5
@@ -291,7 +283,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           {{- if eq .Values.storage.location "fuse" }}
-          {{- /* $fusePath se define al top del template (reusado por la livenessProbe) */}}
+          {{- $fusePath := printf "/home/odoo/data/filestore/%s" (ternary "odoo" .Release.Name .Values.cloudNativePG.enabled) }}
           - name: gcs-fuse-csi-ephemeral
             readOnly: false
             mountPath: {{ $fusePath }}

--- a/charts/adhoc-odoo/templates/reverseProxy/deploy.yaml
+++ b/charts/adhoc-odoo/templates/reverseProxy/deploy.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ingress.reverseProxy.enabled }}
-{{- $nxFusePath := printf "/mnt/filestore/%s" (ternary "odoo" .Release.Name .Values.cloudNativePG.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -81,30 +80,6 @@ spec:
             - name: http
               containerPort: 9080
               protocol: TCP
-          # Readiness: saca el pod del Service si nginx deja de aceptar conexiones en 9080.
-          readinessProbe:
-            tcpSocket:
-              port: 9080
-            initialDelaySeconds: 2
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-            successThreshold: 1
-          {{- if eq .Values.storage.location "fuse" }}
-          # nginx sirve el filestore por sendfile; sin probe seguiría "vivo" con 5xx si el mount
-          # gcsfuse muere. [ -d ], no ls: listar el root del bucket con implicit-dirs cuelga.
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - '[ -d "{{ $nxFusePath }}" ]'
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 5
-            failureThreshold: 8 # 2 min
-            successThreshold: 1
-          {{- end }}
           {{- if eq .Values.adhoc.appType "prod" }}
           resources:
             requests:


### PR DESCRIPTION
## What
Reverts #110's exec `livenessProbe` on fuse bases. `adhoc-odoo` → `tcpSocket:8069`; the `-nx` liveness exec + `readinessProbe:9080` (both added by #110) are removed → no probe, as before #110.

## Why
The gcsfuse mount is pod-scoped: restarting the container does not remount it, so the exec probe can't self-heal and can crashloop (`StartError` on the nested `checklist` mount). Only pod recreation recovers. Detection moves to a Prometheus alert (devops-cloud-infra#46); recovery to a controller. Full analysis in task 71230.

No bump (default render unchanged). Task 71230 / ticket 122777.
