### PR TITLE
feat: chart adhoc-cluster-sentinel

### DIFF
--- a/charts/adhoc-cluster-sentinel/Chart.yaml
+++ b/charts/adhoc-cluster-sentinel/Chart.yaml
@@ -12,7 +12,7 @@ type: application
 
 version: 0.1.0
 
-appVersion: "clusterSentinel-latest"
+appVersion: "clusterSentinel-2026.07.27.1"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-cluster-sentinel/Chart.yaml
+++ b/charts/adhoc-cluster-sentinel/Chart.yaml
@@ -1,0 +1,22 @@
+annotations:
+  category: DevOps
+apiVersion: v2
+name: adhoc-cluster-sentinel
+description: >
+  Plataforma genérica de supervisión de un cluster Kubernetes: corre múltiples
+  checks enchufables que observan el cluster y, ante algo "sano para k8s pero roto
+  de verdad" sostenido, actúan (recrear un pod, etc.) con guardrails uniformes.
+  Checks: gcsfuse-mount (fuente k8s), memory-pressure (fuente Prometheus).
+
+type: application
+
+version: 0.1.0
+
+appVersion: "clusterSentinel-latest"
+
+home: "https://github.com/adhoc-dev/helm-charts"
+sources:
+  - "https://github.com/adhoc-dev/devops-ops-tools"
+maintainers:
+  - name: azacchino
+    email: az@adhoc.inc

--- a/charts/adhoc-cluster-sentinel/templates/NOTES.txt
+++ b/charts/adhoc-cluster-sentinel/templates/NOTES.txt
@@ -1,0 +1,18 @@
+Adhoc Cluster Sentinel deployed in namespace {{ .Release.Namespace }}.
+
+  modeOverride:   {{ .Values.modeOverride | default "(none — checks use their own default)" }}
+  disabledChecks: {{ .Values.disabledChecks | default "(none)" }}
+  prometheusUrl:  {{ .Values.prometheusUrl }}
+
+Checks (mode/thresholds are code defaults per check):
+  gcsfuse-mount    (source: k8s)         restarted gcsfuse sidecar -> recreate pod
+  memory-pressure  (source: Prometheus)  pod near memory limit -> rotate pod
+
+Metrics on :{{ .Values.metricsPort }}/metrics — key series (labeled by check):
+  cluster_sentinel_findings{check="..."}
+  cluster_sentinel_actions_total{check="..."}
+  cluster_sentinel_suppressed_total{check="...",reason="..."}
+  cluster_sentinel_check_last_run_timestamp_seconds{check="..."}   (heartbeat)
+
+Checks ship in observe. Confirm cluster_sentinel_findings flags the right targets,
+then flip a check to enforce (set modeOverride=enforce for all, per the rollout).

--- a/charts/adhoc-cluster-sentinel/templates/_helpers.tpl
+++ b/charts/adhoc-cluster-sentinel/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "adhoc-cluster-sentinel.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "adhoc-cluster-sentinel.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "adhoc-cluster-sentinel.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "adhoc-cluster-sentinel.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "adhoc-cluster-sentinel.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "adhoc-cluster-sentinel.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name
+*/}}
+{{- define "adhoc-cluster-sentinel.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "adhoc-cluster-sentinel.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/adhoc-cluster-sentinel/templates/clusterrole.yaml
+++ b/charts/adhoc-cluster-sentinel/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "adhoc-cluster-sentinel.fullname" . }}
+  labels:
+    {{- include "adhoc-cluster-sentinel.labels" . | nindent 4 }}
+rules:
+  # List pods clusterwide to run the detectors, and delete the confirmed-broken
+  # ones so their Deployment recreates them. This is the controller's whole job.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "delete"]

--- a/charts/adhoc-cluster-sentinel/templates/clusterrolebinding.yaml
+++ b/charts/adhoc-cluster-sentinel/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "adhoc-cluster-sentinel.fullname" . }}
+  labels:
+    {{- include "adhoc-cluster-sentinel.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "adhoc-cluster-sentinel.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "adhoc-cluster-sentinel.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/adhoc-cluster-sentinel/templates/deployment.yaml
+++ b/charts/adhoc-cluster-sentinel/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adhoc-cluster-sentinel.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-cluster-sentinel.labels" . | nindent 4 }}
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # Hard-coded to 1: guardrail state (cooldown, circuit-breaker, confirmation
+  # windows) lives in-process and is not shared, so a second replica could delete
+  # past MAX_RECREATIONS_PER_TICK and ignore cooldowns. Needs leader election first.
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "adhoc-cluster-sentinel.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "adhoc-cluster-sentinel.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "adhoc-cluster-sentinel.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: controller
+          image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
+              protocol: TCP
+          env:
+            - name: MODE_OVERRIDE
+              value: {{ .Values.modeOverride | quote }}
+            - name: DISABLED_CHECKS
+              value: {{ .Values.disabledChecks | quote }}
+            - name: PROMETHEUS_URL
+              value: {{ .Values.prometheusUrl | quote }}
+            - name: METRICS_PORT
+              value: {{ .Values.metricsPort | quote }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/adhoc-cluster-sentinel/templates/deployment.yaml
+++ b/charts/adhoc-cluster-sentinel/templates/deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "adhoc-cluster-sentinel.labels" . | nindent 4 }}
-  {{- with .Values.podAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   # Hard-coded to 1: guardrail state (cooldown, circuit-breaker, confirmation
   # windows) lives in-process and is not shared, so a second replica could delete
@@ -21,6 +17,10 @@ spec:
     metadata:
       labels:
         {{- include "adhoc-cluster-sentinel.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "adhoc-cluster-sentinel.serviceAccountName" . }}
       securityContext:

--- a/charts/adhoc-cluster-sentinel/templates/podmonitor.yaml
+++ b/charts/adhoc-cluster-sentinel/templates/podmonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "adhoc-cluster-sentinel.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-cluster-sentinel.labels" . | nindent 4 }}
+    {{- with .Values.metrics.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "adhoc-cluster-sentinel.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+{{- end }}

--- a/charts/adhoc-cluster-sentinel/templates/serviceaccount.yaml
+++ b/charts/adhoc-cluster-sentinel/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "adhoc-cluster-sentinel.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-cluster-sentinel.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/adhoc-cluster-sentinel/values.yaml
+++ b/charts/adhoc-cluster-sentinel/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: clusterSentinel-latest
+  tag: clusterSentinel-2026.07.27.1
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always

--- a/charts/adhoc-cluster-sentinel/values.yaml
+++ b/charts/adhoc-cluster-sentinel/values.yaml
@@ -1,0 +1,54 @@
+image:
+  repository: docker.io/adhoc/ops-tools
+  tag: clusterSentinel-latest
+  # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
+  digest: ""
+  pullPolicy: Always
+
+# Kubernetes namespace where the controller is deployed.
+namespace: adhoc-cluster-sentinel
+
+# Per-check config (interval, thresholds, selector, mode) lives as code defaults on
+# each Check. These are the only global knobs.
+
+# If set (observe|enforce), forces the mode of ALL checks — for the observe->enforce
+# rollout. Empty = each check uses its own default (checks ship in observe).
+modeOverride: ""
+
+# Comma-separated check names to disable entirely (e.g. "memory-pressure").
+disabledChecks: ""
+
+# Prometheus HTTP API base, shared by Prometheus-sourced checks.
+prometheusUrl: "http://prometheus-operated.monitoring:9090"
+
+# /metrics + /healthz port.
+metricsPort: 9091
+
+# Prometheus scraping of /metrics. Requires the PodMonitor CRD (prometheus-operator);
+# additionalLabels must match the cluster Prometheus's podMonitorSelector (e.g.
+# {release: prom}). Enabled per-deployment (e.g. in the Pulumi values).
+metrics:
+  podMonitor:
+    enabled: false
+    interval: 30s
+    additionalLabels: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    # Check scans are bursty (a k8s check parses the whole fleet each interval); a
+    # tight CPU limit throttles it, stalls the event loop, and fails the liveness probe.
+    cpu: 500m
+    memory: 192Mi
+
+serviceAccount:
+  create: true
+  name: ""
+
+podAnnotations: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Qué

Chart nuevo `adhoc-cluster-sentinel`: el controller **cluster-sentinel**, una plataforma genérica de supervisión de cluster que corre múltiples *checks* enchufables (cada uno con su fuente + detección + acción) sobre recursos "sanos para Kubernetes pero rotos de verdad".

## Contenido

- **Deployment** — 1 réplica (fija: el estado de guardrails es in-process), `runAsNonRoot`, rootfs RO, probes a `/healthz` tolerantes, cpu limit holgado (el scan de un check es bursty).
- **RBAC** — ClusterRole mínimo `pods: [list, delete]` + binding (es todo lo que hacen los checks actuales).
- **PodMonitor** gateado (`metrics.podMonitor.enabled`, `additionalLabels` para matchear el `podMonitorSelector` del Prometheus del cluster).
- **Config por env globales** en values: `modeOverride` (rollout observe→enforce), `disabledChecks`, `prometheusUrl`, `metricsPort`. Los umbrales/selectores por check viven en el código del controller.

Los checks arrancan en **observe** (detectan + emiten métricas, no actúan).

## Companion

- Código del controller + CI: `ingadhoc/devops-ops-tools` (componente `clusterSentinel`).
- Deploy (Pulumi) + alerta de auto-observación: `ingadhoc/devops-cloud-infra`.

## Test plan

- `helm lint` sin fallos; `helm template` renderiza RBAC/Deployment/PodMonitor esperados.
- pre-commit del repo (yamllint + helm validate) en verde.
- Validado en vivo en cluster01 (observe): pod estable, ambos checks reportando métricas, fuente Prometheus respondiendo.