### PR TITLE
chore: OWC — bump chart 0.4.6 -> 0.4.7 (image .40: waiting page de train + estado "tardando más")

### DIFF
--- a/charts/adhoc-wakeup-controller/Chart.yaml
+++ b/charts/adhoc-wakeup-controller/Chart.yaml
@@ -10,9 +10,9 @@ description: >
 
 type: application
 
-version: 0.4.6
+version: 0.4.7
 
-appVersion: "odooWakeupController-2026.07.16.39"
+appVersion: "odooWakeupController-2026.07.31.40"
 
 home: "https://github.com/adhoc-dev/helm-charts"
 sources:

--- a/charts/adhoc-wakeup-controller/values.yaml
+++ b/charts/adhoc-wakeup-controller/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/adhoc/ops-tools
-  tag: odooWakeupController-2026.07.16.39
+  tag: odooWakeupController-2026.07.31.40
   # digest: set to pin to an exact image (overrides tag). Format: sha256:<hash>
   digest: ""
   pullPolicy: Always


### PR DESCRIPTION
Bumpea `adhoc-wakeup-controller` a la imagen recién publicada
`docker.io/adhoc/ops-tools:odooWakeupController-2026.07.31.40`
(build [run 30661045789](https://github.com/ingadhoc/devops-ops-tools/actions/runs/30661045789), disparado por el merge de ingadhoc/devops-ops-tools#49).

## Qué trae la imagen

1. **Waiting page propia del tier `train`** (`trainp` por symlink), adaptación menor de la de `new`.
2. **Segundo estado de espera en todas las plantillas.** Pasados los 45s que declara cada template en `<body data-delay-after>`, la página deja de decir "en unos segundos está lista" y pasa a reconocer la demora: badge `LEVANTANDO BASE`, título "…está tardando un poco **más de lo habitual**" con acento violeta, copy "puede tomar unos minutos más / no hace falta que hagas nada", loader "Seguimos preparando tu base..." y el robot sin "zzz". El umbral y los textos viven en cada template; el JS solo agrega la clase `.delayed`, así que un tier nuevo no lo toca. Sin JS o antes del umbral se ve el estado "levantando".

Alcance de la imagen: las 4 plantillas de tier (`train`/`trainp`, `new` + `old`/`int`, `demo`, `test`) y también `index.html`, la fallback que sirve `prod` y tiers desconocidos.

## Cambios en el chart

Solo el pin de la imagen — sin cambios en templates ni en el resto de `values.yaml`:

| | Antes | Ahora |
|---|---|---|
| `version` | 0.4.6 | 0.4.7 |
| `appVersion` | `odooWakeupController-2026.07.16.39` | `odooWakeupController-2026.07.31.40` |
| `image.tag` | `odooWakeupController-2026.07.16.39` | `odooWakeupController-2026.07.31.40` |

## Verificación

- `helm lint charts/adhoc-wakeup-controller` → 0 failed (solo el INFO preexistente de `icon`).
- pre-commit local: `yamllint` y `helm validate charts (lint + template)` pass.
- El comportamiento de la waiting page se validó en el PR de la imagen: suite del controller verde (`154 passed`), timing del swap probado con stubs de browser, y los dos estados mirados en el sim local.