### PR TITLE
feat: agregar chart adhoc-way-platform (auth-svc + gateway + cert wildcard)

### DIFF
--- a/charts/adhoc-way-platform/Chart.yaml
+++ b/charts/adhoc-way-platform/Chart.yaml
@@ -1,0 +1,22 @@
+annotations:
+  category: DevOps
+apiVersion: v2
+name: adhoc-way-platform
+description: >
+  Singleton chart for the "way" platform: the central signer service
+  (adhocwayAuthSvc, POST /grant + keygen), a dedicated Istio Gateway and a
+  wildcard certificate for the platform domain. Installed once per cluster.
+  Per-user instances are deployed by the adhoc-way-instance chart.
+
+type: application
+
+version: 0.1.0
+
+appVersion: "adhocwayAuthSvc-2026.08.04.1"
+
+home: "https://github.com/adhoc-dev/helm-charts"
+sources:
+  - "https://github.com/ingadhoc/devops-ops-tools"
+maintainers:
+  - name: azacchino
+    email: az@adhoc.inc

--- a/charts/adhoc-way-platform/ci/test-values.yaml
+++ b/charts/adhoc-way-platform/ci/test-values.yaml
@@ -1,0 +1,6 @@
+# Minimal values for `helm lint` / `helm template` (not real secrets).
+entryPubKey: "TEST_ENTRY_PUBKEY_BASE64=="
+authSvc:
+  secret:
+    signingKey: "TEST_SIGNING_KEY_BASE64=="
+    grantToken: "test-grant-token"

--- a/charts/adhoc-way-platform/readme.md
+++ b/charts/adhoc-way-platform/readme.md
@@ -1,0 +1,52 @@
+# adhoc-way-platform
+
+Singleton chart for the "way" platform. Installs the shared, cluster-wide
+components: the signer service `adhocwayAuthSvc`, a dedicated Istio Gateway and a
+wildcard certificate for the platform domain. Install once per cluster. Per-user
+instances are deployed by [`adhoc-way-instance`](../adhoc-way-instance).
+
+## What it installs
+
+- `adhocwayAuthSvc` (Deployment + Service) — `POST /grant` mints entry tokens.
+- Secret with `signing-key` (Ed25519) + `grant-token` (or `existingSecret`).
+- ConfigMap `adhoc-way-platform-entry-pubkey` — the public key consumed by the sidecars.
+- Istio Gateway for `*.<domain>` (binds to the ingress gateway).
+- cert-manager Certificate (wildcard) — TLS secret in `istio-system`.
+
+## Bootstrap (once)
+
+Generate the keypair with the signer image:
+```sh
+docker run --rm <auth-svc-image> keygen
+# WAY_SIGNING_KEY  -> Secret (signing-key)
+# WAY_ENTRY_PUBKEY -> value entryPubKey
+```
+
+## Install
+
+```sh
+helm install adhoc-way-platform charts/adhoc-way-platform -n <ns> --create-namespace \
+  --set domain=<platform-domain> \
+  --set entryPubKey="$WAY_ENTRY_PUBKEY" \
+  --set authSvc.existingSecret=<secret-name>
+```
+Dev (no `existingSecret`): `--set authSvc.secret.signingKey=... --set authSvc.secret.grantToken=...`.
+
+> Deployment-specific values (domain, cert issuer, DNS, secret store) are provided
+> at deploy time (Pulumi) and documented in the private devops docs — not here.
+
+## Main values
+
+| Key | Default | Description |
+|---|---|---|
+| `domain` | `way.example.com` | platform domain for the gateway/cert |
+| `entryPubKey` | `""` | signer Ed25519 public key |
+| `authSvc.image.tag` | `adhocwayAuthSvc-2026.08.04.1` | signer image |
+| `authSvc.existingSecret` | `""` | Secret with `signing-key` + `grant-token` |
+| `gateway.credentialName` | `way-wildcard-tls` | TLS secret read by the gateway |
+| `certificate.issuerRef.name` | `letsencrypt-dns` | cert-manager ClusterIssuer (DNS-01) |
+
+## Key rotation
+
+Re-run `keygen`, update the Secret (`signing-key`) and the ConfigMap (`entryPubKey`);
+ephemeral pods pick up the new public key when recreated.

--- a/charts/adhoc-way-platform/templates/NOTES.txt
+++ b/charts/adhoc-way-platform/templates/NOTES.txt
@@ -1,0 +1,15 @@
+adhoc-way-platform deployed in namespace "{{ .Release.Namespace }}".
+
+  auth-svc : Service {{ include "adhoc-way-platform.fullname" . }}:{{ .Values.authSvc.listenPort }}  (POST /grant, bearer)
+  pubkey   : ConfigMap {{ include "adhoc-way-platform.fullname" . }}-entry-pubkey  (consumed by adhoc-way-instance)
+{{- if .Values.gateway.enabled }}
+  gateway  : {{ include "adhoc-way-platform.fullname" . }}-gateway  for *.{{ .Values.domain }}
+{{- end }}
+{{- if .Values.certificate.enabled }}
+  cert     : wildcard *.{{ .Values.domain }}  (secret {{ .Values.gateway.credentialName }} in {{ .Values.certificate.namespace }})
+{{- end }}
+
+Bootstrap the keypair once:
+  docker run --rm {{ .Values.authSvc.image.repository }}:{{ .Values.authSvc.image.tag }} keygen
+    -> WAY_SIGNING_KEY  to the Secret  (authSvc.existingSecret, or authSvc.secret.signingKey)
+    -> WAY_ENTRY_PUBKEY to the value   entryPubKey

--- a/charts/adhoc-way-platform/templates/_helpers.tpl
+++ b/charts/adhoc-way-platform/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* Chart name. */}}
+{{- define "adhoc-way-platform.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Fully qualified name — singleton, so stable = Chart.Name. */}}
+{{- define "adhoc-way-platform.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/* Common labels. */}}
+{{- define "adhoc-way-platform.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "adhoc-way-platform.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: adhoc-way
+{{- end }}
+
+{{/* Selector labels. */}}
+{{- define "adhoc-way-platform.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "adhoc-way-platform.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: auth-svc
+{{- end }}
+
+{{/* Service account name. */}}
+{{- define "adhoc-way-platform.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "adhoc-way-platform.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* Secret name for signing-key/grant-token (existing, or created by the chart). */}}
+{{- define "adhoc-way-platform.authSvcSecretName" -}}
+{{- if .Values.authSvc.existingSecret }}
+{{- .Values.authSvc.existingSecret }}
+{{- else }}
+{{- printf "%s-authsvc" (include "adhoc-way-platform.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/charts/adhoc-way-platform/templates/authsvc-deployment.yaml
+++ b/charts/adhoc-way-platform/templates/authsvc-deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adhoc-way-platform.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.authSvc.replicas }}
+  selector:
+    matchLabels:
+      {{- include "adhoc-way-platform.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "adhoc-way-platform.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "adhoc-way-platform.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: authsvc
+          image: "{{ .Values.authSvc.image.repository }}{{ if .Values.authSvc.image.digest }}@{{ .Values.authSvc.image.digest }}{{ else }}:{{ .Values.authSvc.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.authSvc.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.authSvc.listenPort }}
+              protocol: TCP
+          env:
+            - name: WAY_LISTEN
+              value: ":{{ .Values.authSvc.listenPort }}"
+            - name: WAY_ENTRY_TTL
+              value: {{ .Values.authSvc.entryTtl | quote }}
+            - name: WAY_HOST_SUFFIX
+              value: {{ .Values.authSvc.hostSuffix | quote }}
+            - name: WAY_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "adhoc-way-platform.authSvcSecretName" . }}
+                  key: signing-key
+            - name: WAY_GRANT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "adhoc-way-platform.authSvcSecretName" . }}
+                  key: grant-token
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.authSvc.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/adhoc-way-platform/templates/authsvc-secret.yaml
+++ b/charts/adhoc-way-platform/templates/authsvc-secret.yaml
@@ -1,0 +1,15 @@
+{{- /* Created only when there is no existingSecret and an inline signingKey was
+       provided (dev). In prod use authSvc.existingSecret. */ -}}
+{{- if and (not .Values.authSvc.existingSecret) .Values.authSvc.secret.signingKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "adhoc-way-platform.authSvcSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  signing-key: {{ .Values.authSvc.secret.signingKey | quote }}
+  grant-token: {{ required "authSvc.secret.grantToken is required together with signingKey" .Values.authSvc.secret.grantToken | quote }}
+{{- end }}

--- a/charts/adhoc-way-platform/templates/authsvc-service.yaml
+++ b/charts/adhoc-way-platform/templates/authsvc-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adhoc-way-platform.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "adhoc-way-platform.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.authSvc.listenPort }}
+      targetPort: http
+      protocol: TCP

--- a/charts/adhoc-way-platform/templates/certificate.yaml
+++ b/charts/adhoc-way-platform/templates/certificate.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "adhoc-way-platform.fullname" . }}-wildcard
+  namespace: {{ .Values.certificate.namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+spec:
+  commonName: '{{ .Values.domain }}'
+  dnsNames:
+    - '{{ .Values.domain }}'
+    - '*.{{ .Values.domain }}'
+  issuerRef:
+    name: {{ .Values.certificate.issuerRef.name | quote }}
+    kind: {{ .Values.certificate.issuerRef.kind }}
+  secretName: {{ .Values.gateway.credentialName | quote }}
+  privateKey:
+    rotationPolicy: Always
+{{- end }}

--- a/charts/adhoc-way-platform/templates/gateway.yaml
+++ b/charts/adhoc-way-platform/templates/gateway.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ include "adhoc-way-platform.fullname" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- toYaml .Values.gateway.istioSelector | nindent 4 }}
+  servers:
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: {{ .Values.gateway.credentialName | quote }}
+        minProtocolVersion: TLSV1_2
+      hosts:
+        - '*.{{ .Values.domain }}'
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - '*.{{ .Values.domain }}'
+      tls:
+        httpsRedirect: true
+{{- end }}

--- a/charts/adhoc-way-platform/templates/pubkey-configmap.yaml
+++ b/charts/adhoc-way-platform/templates/pubkey-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "adhoc-way-platform.fullname" . }}-entry-pubkey
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+data:
+  # Signer Ed25519 public key. Consumed by adhoc-way-instance (WAY_ENTRY_PUBKEY).
+  # Renders empty until entryPubKey is provided; the sidecar fails fast on startup
+  # if it is missing or malformed.
+  pubkey: {{ .Values.entryPubKey | quote }}

--- a/charts/adhoc-way-platform/templates/serviceaccount.yaml
+++ b/charts/adhoc-way-platform/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "adhoc-way-platform.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/adhoc-way-platform/values.yaml
+++ b/charts/adhoc-way-platform/values.yaml
@@ -1,0 +1,64 @@
+nameOverride: ""
+fullnameOverride: ""
+
+# Platform base domain. The Gateway and Certificate cover *.<domain>.
+# The real domain is provided at deploy time (e.g. Pulumi values).
+domain: way.example.com
+
+# Ed25519 public key (NOT secret) of the signer, consumed by the
+# adhocwayAuthProxy sidecars via a ConfigMap. Comes from `keygen` (WAY_ENTRY_PUBKEY).
+entryPubKey: ""
+
+authSvc:
+  image:
+    repository: docker.io/adhoc/ops-tools
+    tag: adhocwayAuthSvc-2026.08.04.1
+    # digest: pin to an exact image (overrides tag). Format: sha256:<hash>
+    digest: ""
+    pullPolicy: Always
+  replicas: 1
+  listenPort: 8090
+  entryTtl: 60s
+  # Only sign entry tokens for hosts under this suffix; set it to match `domain`.
+  hostSuffix: .way.example.com
+  # Secret holding the signing key (Ed25519) and the grant token. If
+  # existingSecret is set it is used (recommended in prod). Otherwise the chart
+  # creates one from `secret` (dev only).
+  existingSecret: ""
+  secret:
+    signingKey: "" # base64 (32B seed or 64B full) — WAY_SIGNING_KEY from keygen
+    grantToken: "" # bearer the caller presents on /grant
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 250m
+      memory: 128Mi
+
+gateway:
+  enabled: true
+  # Selector of the existing Envoy ingress gateway this Gateway binds to.
+  istioSelector:
+    istio: external-ingressgateway
+  # TLS secret created by cert-manager (see `certificate`), read by the gateway.
+  credentialName: way-wildcard-tls
+
+certificate:
+  enabled: true
+  # cert-manager creates the wildcard *.<domain> in this namespace (where the
+  # ingress gateway reads TLS secrets).
+  namespace: istio-system
+  issuerRef:
+    # cert-manager ClusterIssuer (DNS-01). Set the real issuer at deploy time.
+    name: letsencrypt-dns
+    kind: ClusterIssuer
+
+serviceAccount:
+  create: true
+  name: ""
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Qué

Chart **`adhoc-way-platform`** (singleton) de la plataforma *way* — se instala una vez por cluster.

- `adhocwayAuthSvc` (Deployment + Service): firmador `POST /grant`.
- Secret `signing-key` (Ed25519) + `grant-token` (o `existingSecret`).
- ConfigMap `adhoc-way-platform-entry-pubkey` (clave pública, la consumen los sidecars).
- Gateway `*.way.adhoc.inc` (ata al `external-ingressgateway`) + Certificate wildcard (cert-manager, secret TLS en `istio-system`).

Imagen `adhoc/ops-tools:adhocwayAuthSvc-2026.08.04.1`. Molde `adhoc-cluster-sentinel`; patrones Istio de `adhoc-odoo` + `istio-cfg`.

## Bootstrap (deploy-time, no del chart)

`keygen` → `WAY_SIGNING_KEY` al Secret + `WAY_ENTRY_PUBKEY` al value `entryPubKey`; DNS `*.way.adhoc.inc` al ingressgateway (ojo split-DNS).

## Validación

`helm lint` + `helm template` verdes (`ci/test-values.yaml`).

## Relacionado

Complementa `adhoc-way-instance` (chart por-usuario) — PR aparte.
