### PR TITLE
feat: agregar chart adhoc-way-instance (pod tool + sidecar adhocwayAuthProxy)

### DIFF
--- a/charts/adhoc-way-instance/Chart.yaml
+++ b/charts/adhoc-way-instance/Chart.yaml
@@ -1,0 +1,21 @@
+annotations:
+  category: DevOps
+apiVersion: v2
+name: adhoc-way-instance
+description: >
+  Ephemeral per-user instance of the "way" platform: a pod with a third-party
+  web tool and the adhocwayAuthProxy sidecar that only lets the owning user in.
+  Installed once per user (release = host prefix). Requires adhoc-way-platform.
+
+type: application
+
+version: 0.1.0
+
+appVersion: "adhocwayAuthProxy-2026.08.04.1"
+
+home: "https://github.com/adhoc-dev/helm-charts"
+sources:
+  - "https://github.com/ingadhoc/devops-ops-tools"
+maintainers:
+  - name: azacchino
+    email: az@adhoc.inc

--- a/charts/adhoc-way-instance/ci/test-values.yaml
+++ b/charts/adhoc-way-instance/ci/test-values.yaml
@@ -1,0 +1,5 @@
+# Minimal values for `helm lint` / `helm template`.
+host: instance.example.com
+user:
+  id: "1"
+  email: "user@example.com"

--- a/charts/adhoc-way-instance/readme.md
+++ b/charts/adhoc-way-instance/readme.md
@@ -1,0 +1,72 @@
+# adhoc-way-instance
+
+Ephemeral per-user instance of the "way" platform: a pod with a third-party web
+tool (an IDE / agent UI) and the `adhocwayAuthProxy` sidecar that only lets the
+owning user in. Requires [`adhoc-way-platform`](../adhoc-way-platform) in the same
+namespace.
+
+## What it installs
+
+- Deployment with **2 containers**: `auth-proxy` (the only exposed port) + `tool` (listens on `127.0.0.1`).
+- Service (only the proxy port) · Istio VirtualService (`{host}` → platform gateway) · NetworkPolicy.
+
+## Install (one per user, release = host prefix)
+
+```sh
+helm install <prefix> charts/adhoc-way-instance -n <ns> \
+  --set host=<prefix>.<platform-domain> \
+  --set tool.image.tag=<tool-image-tag> \
+  --set tool.port=<tool-port> \
+  --set user.id=<user-id>
+```
+
+> The `tool` **must** listen on `127.0.0.1` (anti-bypass): its port is not exposed
+> in the Service, only the sidecar reaches it. Configure its bind via
+> `tool.command` / `tool.args` / `tool.env`.
+
+## Main values
+
+| Key | Default | Description |
+|---|---|---|
+| `host` | `""` (required) | pod FQDN, `<prefix>.<platform-domain>` |
+| `tool.image.tag` | `openCodeServer-latest` | tool image |
+| `tool.port` | `3000` | tool localhost port |
+| `authProxy.image.tag` | `adhocwayAuthProxy-2026.08.04.1` | sidecar image |
+| `authProxy.entryPubKeyConfigMap` | `adhoc-way-platform-entry-pubkey` | platform ConfigMap |
+| `ingress.istio.gateway` | `adhoc-way-platform-gateway` | platform Gateway |
+
+## Integration contract (for the orchestrator)
+
+An orchestrator (an Odoo module) manages the lifecycle. Three hook points:
+
+### 1. Activate (create the pod)
+
+`helm install <prefix> adhoc-way-instance -n <ns> --set host=... --set tool.image...=... --set user...`
+— or the equivalent via the Kubernetes API. The pod is dedicated to a single user.
+
+### 2. Enter (authorize the user)
+
+1. The backend (with the user already authenticated) calls the signer:
+   ```
+   POST http://<auth-svc-service>:<port>/grant
+   Authorization: Bearer <grant-token>
+   Content-Type: application/json
+
+   {"user_id": "<id>", "email": "<email>", "host": "<host>"}
+   ```
+   `200` → `{ "token", "entry_url", "expires_at" }`
+2. Redirect the user's browser to `entry_url` (`https://<host>/_auth?token=...`).
+   The sidecar exchanges the single-use token (~60s) for the session cookie.
+
+Full `/grant` contract and errors: see `adhocwayAuthSvc` in `ingadhoc/devops-ops-tools`.
+
+### 3. Destroy (ephemeral)
+
+`helm uninstall <prefix> -n <ns>` — kills the pod (and the sidecar) → access is cut.
+
+### Notes
+
+- The grant token is the same bearer as the platform Secret; keep it server-side (never expose it to the browser).
+- `/grant` only signs for hosts under the configured suffix — validate the prefix on the caller side too.
+- Immediate revocation = destroy the instance. The entry token's short `exp` (~60s) is the safety net.
+- One pod = one user: the token's `aud == host` guarantees a token from another instance will not work here.

--- a/charts/adhoc-way-instance/templates/NOTES.txt
+++ b/charts/adhoc-way-instance/templates/NOTES.txt
@@ -1,0 +1,11 @@
+way instance "{{ .Release.Name }}" deployed in namespace "{{ .Release.Namespace }}".
+
+  host : https://{{ .Values.host }}
+  tool : {{ .Values.tool.image.repository }}:{{ .Values.tool.image.tag }}  (listens on 127.0.0.1:{{ .Values.tool.port }})
+  gate : adhocwayAuthProxy  (port {{ .Values.authProxy.listenPort }}, the only exposed one)
+
+Entry: the orchestrator calls POST /grant on the signer and redirects the user to
+  https://{{ .Values.host }}/_auth?token=<JWT>
+
+Reminder: the tool MUST bind 127.0.0.1 (not 0.0.0.0). Configure it via
+tool.command / tool.args / tool.env.

--- a/charts/adhoc-way-instance/templates/_helpers.tpl
+++ b/charts/adhoc-way-instance/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/* Chart name. */}}
+{{- define "adhoc-way-instance.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Fully qualified name — per instance, includes the release (prefix). */}}
+{{- define "adhoc-way-instance.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Common labels. */}}
+{{- define "adhoc-way-instance.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "adhoc-way-instance.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: adhoc-way
+{{- end }}
+
+{{/* Selector labels. */}}
+{{- define "adhoc-way-instance.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "adhoc-way-instance.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: way-instance
+{{- end }}

--- a/charts/adhoc-way-instance/templates/deployment.yaml
+++ b/charts/adhoc-way-instance/templates/deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "adhoc-way-instance.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-instance.labels" . | nindent 4 }}
+  annotations:
+    adhoc.inc/way-host: {{ .Values.host | quote }}
+    {{- with .Values.user.id }}
+    adhoc.inc/way-user-id: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.user.email }}
+    adhoc.inc/way-user-email: {{ . | quote }}
+    {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "adhoc-way-instance.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "adhoc-way-instance.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        # --- gate: the only exposed port of the pod ---
+        - name: auth-proxy
+          image: "{{ .Values.authProxy.image.repository }}{{ if .Values.authProxy.image.digest }}@{{ .Values.authProxy.image.digest }}{{ else }}:{{ .Values.authProxy.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.authProxy.listenPort }}
+              protocol: TCP
+          env:
+            - name: WAY_HOST
+              value: {{ .Values.host | quote }}
+            - name: WAY_UPSTREAM
+              value: "http://127.0.0.1:{{ .Values.tool.port }}"
+            - name: WAY_LISTEN
+              value: ":{{ .Values.authProxy.listenPort }}"
+            - name: WAY_COOKIE_NAME
+              value: {{ .Values.authProxy.cookieName | quote }}
+            - name: WAY_SESSION_TTL
+              value: {{ .Values.authProxy.sessionTtl | quote }}
+            - name: WAY_MAX_ENTRY_TTL
+              value: {{ .Values.authProxy.maxEntryTtl | quote }}
+            - name: WAY_ENTRY_PUBKEY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.authProxy.entryPubKeyConfigMap }}
+                  key: {{ .Values.authProxy.entryPubKeyKey }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.authProxy.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+        # --- tool: listens on 127.0.0.1, no port in the Service ---
+        - name: tool
+          image: "{{ .Values.tool.image.repository }}{{ if .Values.tool.image.digest }}@{{ .Values.tool.image.digest }}{{ else }}:{{ .Values.tool.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.tool.image.pullPolicy }}
+          {{- with .Values.tool.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tool.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tool.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tool.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.tool.resources | nindent 12 }}
+          {{- with .Values.tool.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/adhoc-way-instance/templates/networkpolicy.yaml
+++ b/charts/adhoc-way-instance/templates/networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "adhoc-way-instance.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-instance.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "adhoc-way-instance.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Ingress to the proxy port is allowed only from the ingress gateway
+    # namespace (namespace-scoped, not a specific pod). The tool on 127.0.0.1
+    # is unreachable from the cluster regardless.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.gatewayNamespace }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.authProxy.listenPort }}
+{{- end }}

--- a/charts/adhoc-way-instance/templates/service.yaml
+++ b/charts/adhoc-way-instance/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "adhoc-way-instance.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-instance.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "adhoc-way-instance.selectorLabels" . | nindent 4 }}
+  ports:
+    # Only the auth-proxy port. The tool (127.0.0.1) is not exposed.
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/adhoc-way-instance/templates/virtualservice.yaml
+++ b/charts/adhoc-way-instance/templates/virtualservice.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingress.istio.enabled }}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "adhoc-way-instance.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-instance.labels" . | nindent 4 }}
+spec:
+  hosts:
+    - {{ .Values.host | quote }}
+  gateways:
+    - {{ .Values.ingress.istio.gateway }}
+  http:
+    # Single catch-all route; Istio passes WebSocket transparently on the same host.
+    - route:
+        - destination:
+            host: {{ printf "%s.%s.svc.cluster.local" (include "adhoc-way-instance.fullname" .) .Release.Namespace }}
+            port:
+              number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/adhoc-way-instance/values.yaml
+++ b/charts/adhoc-way-instance/values.yaml
@@ -1,0 +1,79 @@
+nameOverride: ""
+fullnameOverride: ""
+
+# Full host served by the pod, e.g. <prefix>.<platform-domain>.  (REQUIRED)
+host: ""
+
+# Odoo user that owns this instance (informational; goes to annotations).
+user:
+  id: ""
+  email: ""
+
+# --- The third-party web tool that runs in the pod ---
+# It MUST listen on 127.0.0.1 (anti-bypass): its port is not exposed in the
+# Service, only the auth-proxy sidecar reaches it inside the pod.
+tool:
+  image:
+    repository: docker.io/adhoc/ops-tools
+    tag: openCodeServer-latest
+    # digest: pin to an exact image (overrides tag). Format: sha256:<hash>
+    digest: ""
+    pullPolicy: Always
+  # Port the tool listens on (localhost).
+  port: 3000
+  command: []
+  args: []
+  env: []
+  volumeMounts: []
+  securityContext: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+# --- Authentication sidecar (adhocwayAuthProxy) ---
+authProxy:
+  image:
+    repository: docker.io/adhoc/ops-tools
+    tag: adhocwayAuthProxy-2026.08.04.1
+    digest: ""
+    pullPolicy: Always
+  listenPort: 8080
+  cookieName: way_session
+  sessionTtl: 12h
+  maxEntryTtl: 5m
+  # ConfigMap (same namespace) with the signer Ed25519 public key.
+  # Created by adhoc-way-platform.
+  entryPubKeyConfigMap: adhoc-way-platform-entry-pubkey
+  entryPubKeyKey: pubkey
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+service:
+  port: 80
+
+ingress:
+  istio:
+    enabled: true
+    # Dedicated *.<domain> Gateway (from the adhoc-way-platform chart).
+    gateway: adhoc-way-platform-gateway
+
+# Accept ingress to the proxy port only from the ingress gateway namespace.
+# Defense in depth — the tool already listens only on 127.0.0.1.
+networkPolicy:
+  enabled: true
+  gatewayNamespace: istio-system
+
+volumes: []
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Qué

Chart **`adhoc-way-instance`** (por usuario) de la plataforma *way*. Requiere `adhoc-way-platform`.

- Deployment 2-containers: `tool` (en `127.0.0.1`, sin puerto en el Service) + `auth-proxy` (adhocwayAuthProxy, único puerto expuesto).
- Service (sólo el proxy) · VirtualService (`{host}` → gateway del platform) · NetworkPolicy.
- Referencia por nombre el ConfigMap `adhoc-way-platform-entry-pubkey` y el Gateway `adhoc-way-platform-gateway`.

Imagen `adhoc/ops-tools:adhocwayAuthProxy-2026.08.04.1`.

## Integración Odoo ("puntas")

El `readme.md` documenta el ciclo que maneja el módulo Odoo (lo hace vib): **activar** (`helm install` + params), **entrar** (`POST /grant` → redirect a `entry_url`), **destruir** (`helm uninstall`).

## Validación

`helm lint` + `helm template` verdes (`ci/test-values.yaml`).

## Relacionado

Depende de `adhoc-way-platform` (PR aparte) — acopla por nombre de ConfigMap/Gateway.
