### PR TITLE
feat: sacar Postgres (5432) del sidecar de Istio en adhoc-odoo

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -285,17 +285,19 @@ Sin istio.enabled devuelve "open" (los recursos de egress no aplican).
 {{- end -}}
 
 {{/*
-adhoc-odoo.egressExcludePorts — puertos que se SACAN del sidecar (server-first: SMTP/SSH).
-Default 587,465,25,22,2525 (SMTP estándar 587/465/25 + Mailgun-2525 + SSH 22) MÁS el
-odoo.smtp.port configurado si es no estándar. Los puertos SMTP son server-speaks-first: si
+adhoc-odoo.egressExcludePorts — puertos que se SACAN del sidecar (server-first: SMTP/SSH + PG).
+Default 587,465,25,22,2525,5432 (SMTP estándar 587/465/25 + Mailgun-2525 + SSH 22 + Postgres)
+MÁS el odoo.smtp.port configurado si es no estándar. Los puertos SMTP son server-speaks-first: si
 pasan por el sidecar, el tls_inspector del egress logging los cuelga (timeout 15s → reset,
 incluso en observe). Auto-derivar smtp.port evita que un relay en puerto no estándar (p.ej.
-Mailgun 2525) quede bloqueado. Nunca agrega 443 (debe pasar por el sidecar). El override de
-podAnnotations lo maneja cada template; este helper es el DEFAULT.
+Mailgun 2525) quede bloqueado. 5432 entra por otra razón — LATENCIA: es el path caliente de Odoo
+y cada salto por el sidecar cuesta ~0,78 ms/consulta; el CNPG no está en el mesh, así que el
+passthrough no aporta mTLS ni políticas. Nunca agrega 443 (debe pasar por el sidecar). El override
+de podAnnotations lo maneja cada template; este helper es el DEFAULT.
 */}}
 {{- define "adhoc-odoo.egressExcludePorts" -}}
 {{- $egress := (.Values.ingress.istio.egress | default dict) -}}
-{{- $base := ($egress.excludeOutboundPorts | default "587,465,25,22,2525") -}}
+{{- $base := ($egress.excludeOutboundPorts | default "587,465,25,22,2525,5432") -}}
 {{- $ports := list -}}
 {{- range (splitList "," $base) -}}
 {{- $p := trim . -}}

--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -285,7 +285,8 @@ Sin istio.enabled devuelve "open" (los recursos de egress no aplican).
 {{- end -}}
 
 {{/*
-adhoc-odoo.egressExcludePorts — puertos que se SACAN del sidecar (server-first: SMTP/SSH + PG).
+adhoc-odoo.egressExcludePorts — puertos que se SACAN del sidecar. Dos motivos distintos conviven
+en esta lista: SMTP/SSH salen por ser server-first, y Postgres por latencia (NO es server-first).
 Default 587,465,25,22,2525,5432 (SMTP estándar 587/465/25 + Mailgun-2525 + SSH 22 + Postgres)
 MÁS el odoo.smtp.port configurado si es no estándar. Los puertos SMTP son server-speaks-first: si
 pasan por el sidecar, el tls_inspector del egress logging los cuelga (timeout 15s → reset,

--- a/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/egress-networkpolicy.yaml
@@ -17,7 +17,11 @@
 {{- if has "443" $exclPorts -}}
 {{- fail "ingress.istio.egress.excludeOutboundPorts no puede incluir 443: el HTTPS debe pasar por el sidecar para que aplique la whitelist. Quitá 443 de la lista." -}}
 {{- end -}}
-{{- $smtpPorts := without $exclPorts "22" -}}
+{{- /* 22 (SSH) tiene su propia regla con los CIDR de GitHub, y 5432 (Postgres) sale por latencia
+   contra la DB in-cluster — no contra el relay del tenant. Si 5432 entrara acá, outboundTcpCidrs
+   (pensado para SMTP) terminaría abriendo el puerto de la base hacia los rangos del proveedor
+   de mail. La DB in-cluster ya está cubierta por la regla namespaceSelector de más abajo. */ -}}
+{{- $smtpPorts := without $exclPorts "22" "5432" -}}
 {{- $smtpCidrs := ($egress.outboundTcpCidrs | default list) -}}
 {{- $sshOn := and ($egress.repoSsh) .Values.adhoc.devMode (has "22" $exclPorts) -}}
 {{- /* GitHub: rangos git de https://api.github.com/meta ("git"). Override/sync vía egress.repoSshCidrs. */ -}}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -97,6 +97,10 @@ ingress:
       # ~0,78 ms, más que el tiempo que la propia consulta pasa en el motor. El CNPG no está en
       # el mesh (sin sidecar), así que el passthrough no aporta mTLS ni políticas. Bajo enforce
       # la NP -egress-meshed lo restringe a in-cluster + RFC1918 y le deniega Internet.
+      # ⚠️ AL ACTUALIZAR: un tenant con Postgres EXTERNO que haya puesto 5432 en openTcpPorts
+      # (para que salga logueado por el sidecar) va a fallar el upgrade — el chart rechaza a
+      # propósito que un puerto esté en las dos listas. Sacarlo de una: de openTcpPorts si
+      # prefiere la latencia baja, o de esta lista (override local) si prefiere el logging.
       excludeOutboundPorts: "587,465,25,22,2525,5432"
       # IPs que se SACAN del redirect del sidecar (salen directo, gobernadas por la NetworkPolicy).
       # El metadata server de GKE (169.254.169.254) SIEMPRE se excluye (baked-in): la Workload

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -92,7 +92,12 @@ ingress:
       # SACAN del sidecar (estos puertos) y se gobiernan por NetworkPolicy, no por ServiceEntry.
       # El puerto SMTP configurado (odoo.smtp.port) se AUTO-INCLUYE (cubre relays en puertos no
       # estándar sin tocar esta lista). Ver "Egress control" en doc/adhoc-odoo.md.
-      excludeOutboundPorts: "587,465,25,22,2525"
+      # 5432 (Postgres) entra por LATENCIA, no por server-first: es el path caliente de Odoo
+      # (~126 consultas/s medidas en una base productiva) y cada salto por el sidecar cuesta
+      # ~0,78 ms, más que el tiempo que la propia consulta pasa en el motor. El CNPG no está en
+      # el mesh (sin sidecar), así que el passthrough no aporta mTLS ni políticas. Bajo enforce
+      # la NP -egress-meshed lo restringe a in-cluster + RFC1918 y le deniega Internet.
+      excludeOutboundPorts: "587,465,25,22,2525,5432"
       # IPs que se SACAN del redirect del sidecar (salen directo, gobernadas por la NetworkPolicy).
       # El metadata server de GKE (169.254.169.254) SIEMPRE se excluye (baked-in): la Workload
       # Identity de gcsfuse lo consulta por HTTP:80 y bajo enforce el sidecar lo bloquearía (502) →

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -68,8 +68,9 @@ ingress:
                                 #   Baseline baked-in: VIP de Private Google Access (GCS)
       openTcpPorts: []          # enforce: puertos "abiertos a priori" a CUALQUIER host, LOGUEADOS
                                 #   (client-first: HTTP/PG/Redis/465...). NO server-first, NO 80/443
-      # SMTP/SSH (server-first) se sacan del sidecar y se gobiernan por NetworkPolicy (no ServiceEntry):
-      excludeOutboundPorts: "587,465,25,22,2525"  # bypassan el sidecar; odoo.smtp.port se auto-incluye
+      # SMTP/SSH (server-first) se sacan del sidecar y se gobiernan por NetworkPolicy (no ServiceEntry).
+      # 5432 también sale del sidecar, pero por latencia (ver nota más abajo), no por server-first:
+      excludeOutboundPorts: "587,465,25,22,2525,5432"  # bypassan el sidecar; odoo.smtp.port se auto-incluye
       excludeOutboundIPRanges: ""  # IPs extra fuera del redirect; el metadata server (169.254.169.254) ya va baked-in
       outboundTcpCidrs: []      # enforce: CIDRs permitidos en esos puertos (rango del relay SMTP)
       repoSsh: true             # enforce: agrega CIDRs de GitHub SSH a la NP, SOLO con adhoc.devMode
@@ -116,13 +117,21 @@ Postura de salida por tenant vía `ingress.istio.egress.mode` (solo con istio ha
 **SMTP y SSH NO van por ServiceEntry.** Son *server-speaks-first* (el servidor manda el banner
 primero) y cuelgan el `tls_inspector` del egress logging → **incluso en `observe`** la conexión
 se resetea (15s de timeout); bajo `REGISTRY_ONLY` irían a BlackHole. Por eso esos puertos
-(`excludeOutboundPorts`, default `587,465,25,22,2525`) se **sacan del sidecar** y se allowlistean
-por **CIDR** en la NetworkPolicy del pod meshed. **El puerto SMTP configurado (`odoo.smtp.port`)
-se auto-incluye** en la lista efectiva — un relay en puerto no estándar (p.ej. Mailgun `2525`)
-queda excluido sin tener que editar `excludeOutboundPorts`:
+(`excludeOutboundPorts`, default `587,465,25,22,2525,5432`) se **sacan del sidecar** y se
+allowlistean por **CIDR** en la NetworkPolicy del pod meshed. **El puerto SMTP configurado
+(`odoo.smtp.port`) se auto-incluye** en la lista efectiva — un relay en puerto no estándar (p.ej.
+Mailgun `2525`) queda excluido sin tener que editar `excludeOutboundPorts`:
 
-- **outboundTcpCidrs** — CIDRs permitidos en los puertos SMTP (los excluidos **salvo 22**). No se
-  puede derivar de un hostname: usar el rango publicado del proveedor o la IP del relay.
+- **outboundTcpCidrs** — CIDRs permitidos en los puertos SMTP (los excluidos **salvo 22 y 5432**).
+  No se puede derivar de un hostname: usar el rango publicado del proveedor o la IP del relay.
+
+> **`5432` está en la lista por otro motivo: latencia, no server-first.** Postgres es el camino
+> más caliente de Odoo y cada salto por el sidecar agrega ~0,78 ms por consulta; el pod CNPG no
+> está en el mesh, así que el passthrough no aportaba mTLS ni políticas. Queda fuera de la regla
+> de `outboundTcpCidrs` (es tráfico a la DB in-cluster, no al relay del tenant): lo cubre la
+> regla `namespaceSelector` de la NetworkPolicy meshed. **Si un tenant usa Postgres externo con
+> `5432` en `openTcpPorts`, hay que sacarlo de una de las dos listas** — el chart rechaza a
+> propósito que un puerto esté en ambas.
 - **repoSsh** (default `true`) — agrega los CIDR de GitHub (`repoSshCidrs`, rangos "git" de
   `api.github.com/meta`) a la NetworkPolicy **solo en el puerto 22**. **Solo surte efecto con
   `adhoc.devMode=true`** (es no-op en prod → ahí git-SSH queda bloqueado igual). Con `devMode` abre


### PR DESCRIPTION
> [!IMPORTANT]
> **Corrección posterior al merge.** La cifra de overhead publicada abajo (`~0,78 ms`) estaba inflada: se midió sobre una base productiva durante su ventana de CPU throttling de Postgres, y el congelamiento del backend —latencia del motor— se le atribuyó al proxy. El valor real, medido con un A/B controlado, es **~0,15 ms por consulta**. La tabla ya está corregida; el detalle de la medición y el pitfall están en #125. El cambio de este PR sigue siendo correcto: el A/B confirma que el overhead desaparece al excluir el puerto.

## Qué cambia

Suma `5432` a `ingress.istio.egress.excludeOutboundPorts`, sacando el tráfico a Postgres del sidecar de Istio en los pods de Odoo. Se actualiza también el fallback del helper `adhoc-odoo.egressExcludePorts` para que no diverja del default de `values.yaml`.

## Por qué

El path a Postgres es el más caliente de Odoo. Medido con un A/B entre bases con el puerto excluido y bases con el puerto interceptado, normalizando la red con una sonda al puerto 22:

| Medición | Valor |
|---|---|
| Volumen | ~126 consultas/s (49 M en 108 h) |
| Overhead atribuible a Envoy | **~0,15 ms por consulta** |
| Espera acumulada a ese volumen | ~2 h cada 108 h |

El pod CNPG no está en el mesh, así que ese costo no compra nada a cambio. Es una mejora modesta pero gratuita; el cuello de botella de las bases afectadas es el throttling del propio Postgres, no el proxy.

## Por qué es seguro

- El pod CNPG **no está en el mesh** (no tiene sidecar inyectado), así que el tráfico ya viaja en passthrough plaintext: no hay mTLS que perder.
- No hay `AuthorizationPolicy` ni `PeerAuthentication` aplicando sobre ese tráfico, ni en los namespaces de tenant ni a nivel mesh.
- Bajo `enforce`, la NetworkPolicy `-egress-meshed` que ya genera el chart gobierna los puertos excluidos: permite `namespaceSelector: {}` + RFC1918 y no tiene regla `0.0.0.0/0` salvo en 443, así que 5432 queda restringido a in-cluster y con Internet denegado.
- Bajo `observe` (modo actual de la flota) no se abre acceso nuevo: el sidecar en ALLOW_ANY ya dejaba salir ese tráfico. Lo que se pierde temporalmente es el registro de esas conexiones en el sidecar.
- `5432` queda fuera de la regla derivada de `outboundTcpCidrs`: esos CIDR son los del relay SMTP del tenant y no corresponde abrirles el puerto de la base.

## Test plan

- `helm lint` y `helm template` con los values de una release real: la annotation renderiza `"587,465,25,22,2525,5432"`.
- Los guards del chart siguen activos: falla si un puerto está en `openTcpPorts` y `excludeOutboundPorts` a la vez, y si se intenta excluir 443.
- pre-commit (`yamllint` + `helm validate charts`) en verde.
- **Validado en una base de test**: el pod levanta 3/3 con el sidecar inyectado, Odoo conecta a Postgres normalmente y el overhead desaparece (delta ~0 contra ~0,14 ms del grupo de control).

Sin bump de versión: el cambio es backward-compatible.

Seguimiento de configuración relacionada: https://www.adhoc.inc/odoo/project.task/71967