### PR TITLE
fix: adhoc-odoo — perTryTimeout y retryOn de retries en VS KEDA sin OWC

### DIFF
--- a/charts/adhoc-odoo/changelog.md
+++ b/charts/adhoc-odoo/changelog.md
@@ -4,6 +4,19 @@
 
 Fixes:
 
+- Istio VS (KEDA sin wakeup controller): `perTryTimeout` del bloque `retries`
+  pasa de un hardcode de `5s` a `odoo.performance.maxTimeReal`, y `attempts`
+  baja de `10` a `2`. El `5s` fijo (agregado en #115 para el cold-start de
+  KEDA) aplicaba también una vez el pod ya estaba despierto, cortando y
+  reintentando requests legítimas más lentas (reportes pesados, imports) y
+  arriesgando duplicar acciones no idempotentes sobre un backend real — el
+  mismo riesgo que #115 buscaba evitar. Además, `retryOn` saca `gateway-error`
+  (queda solo `connect-failure,refused-stream`): ese valor cubre tanto una
+  respuesta 5xx real como el propio `perTryTimeout` expirando, y en este
+  segundo caso el backend puede seguir procesando la request vieja sin que
+  hayamos recibido nada — ya no hace falta para el cold-start porque el nuevo
+  `perTryTimeout` le da margen de sobra en el primer intento. Sin cambio para
+  bases con `wakeupController.enabled=true` o sin KEDA (sin bloque `retries`).
 - Bases `fuse`: se revierte la `livenessProbe` exec de #110 (`adhoc-odoo` y `-nx`)
   y se vuelve a `tcpSocket:8069`. La reproducción mostró que un restart de container
   no re-monta el gcsfuse (mount pod-scoped): el exec no auto-recuperaba y podía

--- a/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
+++ b/charts/adhoc-odoo/templates/odoo/in-istio/virtualService.yaml
@@ -10,6 +10,7 @@
 {{- $srvPort := 80 }}
 {{- $isKedaEnabled := eq (include "keda.enabled" . | trim) "true" -}}
 {{- $isWakeupEnabled := eq (include "wakeupController.enabled" . | trim) "true" -}}
+{{- $kedaRetryPerTry := printf "%ds" (int .Values.odoo.performance.maxTimeReal) -}}
 {{- if .Values.ingress.reverseProxy.enabled }}
 {{- $srvHttp = printf "%s-nginx" (include "adhoc-odoo.serviceNameSuffix" .) }}
 {{- $srvWs = printf "%s-nginx" (include "adhoc-odoo.serviceNameSuffix" .) }}
@@ -60,12 +61,15 @@ spec:
             port:
               number: {{ $srvPort }}
       {{- if and $isKedaEnabled (not $isWakeupEnabled) }}
-      # Ver mismo bloque en el VS "*-custom": solo cold-start de KEDA sin
-      # wakeup controller, seguro porque todavía no hay backend real.
+      # KEDA sin wakeup controller: perTryTimeout = maxTimeReal (no cortar
+      # requests legítimas en curso). retryOn excluye gateway-error a
+      # propósito: solo reintenta cuando no hubo respuesta del todo, nunca
+      # sobre un intento que expiró con el backend posiblemente procesando.
+      # Ver mismo bloque en el VS "*-custom".
       retries:
-        attempts: 10
-        perTryTimeout: 5s
-        retryOn: gateway-error,connect-failure,refused-stream
+        attempts: 2
+        perTryTimeout: {{ $kedaRetryPerTry }}
+        retryOn: connect-failure,refused-stream
       {{- end }}
       {{- if gt $usewebsocket 0 }}
     - match:
@@ -158,15 +162,11 @@ spec:
             port:
               number: {{ $srvPort }}
       {{- if and $isKedaEnabled (not $isWakeupEnabled) }}
-      # Solo para KEDA sin wakeup controller: durante el cold-start el
-      # interceptor de KEDA sostiene la conexión sin haber llegado a un backend
-      # real, así que reintentar acá no duplica nada (gateway-error = sigue
-      # dormido). Sin esta condición, el mismo bloque reintenta sobre backends
-      # ya despiertos y duplica cualquier acción no idempotente en curso.
+      # Ver mismo bloque en el VS "*-shared".
       retries:
-        attempts: 10
-        perTryTimeout: 5s
-        retryOn: gateway-error,connect-failure,refused-stream
+        attempts: 2
+        perTryTimeout: {{ $kedaRetryPerTry }}
+        retryOn: connect-failure,refused-stream
       {{- end }}
       {{- if gt $usewebsocket 0 }}
     - match:


### PR DESCRIPTION
## Qué cambia

El bloque `retries` de la VS Istio (agregado en #115 para el cold-start de KEDA sin wakeup controller) usaba `perTryTimeout: 5s` fijo y `retryOn` incluía `gateway-error`. Al ser una condición estática por tier (`isKedaEnabled && !isWakeupEnabled`), ese mismo timeout se sigue aplicando indefinidamente una vez el pod ya está despierto — no solo durante el cold-start real.

Consecuencia: cualquier request legítima más lenta que 5s (un reporte pesado, un import) cae en retry storm y termina en 504, reintentando además sobre un backend real ya despierto — el mismo riesgo de duplicar acciones no idempotentes que #115 quiso evitar para prod/OWC.

## Fix

- `perTryTimeout` pasa de `5s` fijo a `odoo.performance.maxTimeReal` (el límite que Odoo mismo ya tolera por request, vía `LIMIT_TIME_REAL`).
- `attempts` baja de `10` a `2` para acotar el peor caso.
- `retryOn` saca `gateway-error`, queda solo `connect-failure,refused-stream`. `gateway-error` dispara retry tanto sobre una respuesta 5xx real como sobre el propio `perTryTimeout` expirando — y en ese segundo caso el backend puede seguir procesando la request vieja sin que hayamos recibido nada. Con el nuevo `perTryTimeout` el cold-start ya tiene margen de sobra en el primer intento, así que retry solo tiene sentido cuando no hubo respuesta del todo (falla de conexión, stream rechazado).
- Sin cambio de comportamiento para bases con `wakeupController.enabled=true` o sin KEDA (no tienen este bloque).
- Sin bump de versión (`0.3.4`, convención del repo).

## Test plan

- `helm lint` + `helm template` en los 3 escenarios reales: KEDA sin OWC (retries con los nuevos valores), KEDA+OWC y sin KEDA (sin bloque `retries`, sin regresión).
- Fixtures de CI existentes (`entrypoint-token-values`, `legacy-no-wakeupcontroller-values`) pasan.
- Verificado contra la config real de Envoy en un ingress gateway vivo (`config_dump`) que la ruta no tiene un `timeout` general implícito que capee el `perTryTimeout` nuevo — Istio compila la ausencia de `timeout` explícito a `0s` (deshabilitado), no al default de 15s de Envoy puro.