### PR TITLE
fix: corregir el overhead medido del sidecar en 5432 (~0,78 ms → ~0,15 ms)

### DIFF
--- a/charts/adhoc-odoo/templates/_helpers.tpl
+++ b/charts/adhoc-odoo/templates/_helpers.tpl
@@ -292,7 +292,7 @@ MÁS el odoo.smtp.port configurado si es no estándar. Los puertos SMTP son serv
 pasan por el sidecar, el tls_inspector del egress logging los cuelga (timeout 15s → reset,
 incluso en observe). Auto-derivar smtp.port evita que un relay en puerto no estándar (p.ej.
 Mailgun 2525) quede bloqueado. 5432 entra por otra razón — LATENCIA: es el path caliente de Odoo
-y cada salto por el sidecar cuesta ~0,78 ms/consulta; el CNPG no está en el mesh, así que el
+y cada salto por el sidecar cuesta ~0,15 ms/consulta; el CNPG no está en el mesh, así que el
 passthrough no aporta mTLS ni políticas. Nunca agrega 443 (debe pasar por el sidecar). El override
 de podAnnotations lo maneja cada template; este helper es el DEFAULT.
 */}}

--- a/charts/adhoc-odoo/values.yaml
+++ b/charts/adhoc-odoo/values.yaml
@@ -94,9 +94,10 @@ ingress:
       # estándar sin tocar esta lista). Ver "Egress control" en doc/adhoc-odoo.md.
       # 5432 (Postgres) entra por LATENCIA, no por server-first: es el path caliente de Odoo
       # (~126 consultas/s medidas en una base productiva) y cada salto por el sidecar cuesta
-      # ~0,78 ms, más que el tiempo que la propia consulta pasa en el motor. El CNPG no está en
-      # el mesh (sin sidecar), así que el passthrough no aporta mTLS ni políticas. Bajo enforce
-      # la NP -egress-meshed lo restringe a in-cluster + RFC1918 y le deniega Internet.
+      # ~0,15 ms por consulta (A/B contra bases con el puerto aún interceptado; ~2 h de espera
+      # acumulada cada 108 h a ese volumen). El CNPG no está en el mesh (sin sidecar), así que
+      # el passthrough no aporta mTLS ni políticas: solo latencia. Bajo enforce la NP
+      # -egress-meshed lo restringe a in-cluster + RFC1918 y le deniega Internet.
       # ⚠️ AL ACTUALIZAR: un tenant con Postgres EXTERNO que haya puesto 5432 en openTcpPorts
       # (para que salga logueado por el sidecar) va a fallar el upgrade — el chart rechaza a
       # propósito que un puerto esté en las dos listas. Sacarlo de una: de openTcpPorts si

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -130,13 +130,13 @@ Mailgun `2525`) queda excluido sin tener que editar `excludeOutboundPorts`:
 > un A/B entre bases con el puerto excluido y bases con el puerto aún interceptado, normalizando
 > la latencia de red con una sonda al puerto 22 (que ya estaba excluido). A ~126 consultas/s son
 > ~2 h de espera acumulada cada 108 h. ⚠️ **No medir esto durante una ventana de CPU throttling
-> del propio Postgres**: el congelamiento del backend infla el `SELECT 1` y se atribuye al proxy
-> latencia que es del motor (nos pasó: 0,85 ms aparentes contra 0,13 ms reales). El pod CNPG no
-> está en el mesh, así que el passthrough no aportaba mTLS ni políticas. Queda fuera de la regla
-> de `outboundTcpCidrs` (es tráfico a la DB in-cluster, no al relay del tenant): lo cubre la
-> regla `namespaceSelector` de la NetworkPolicy meshed. **Si un tenant usa Postgres externo con
-> `5432` en `openTcpPorts`, hay que sacarlo de una de las dos listas** — el chart rechaza a
-> propósito que un puerto esté en ambas.
+> del propio Postgres**: el congelamiento del backend infla el `SELECT 1`, y esa demora —que es
+> del motor— termina contabilizada como si fuera del proxy (nos pasó: 0,85 ms aparentes contra
+> 0,13 ms reales). El pod CNPG no está en el mesh, así que el passthrough no aportaba mTLS ni
+> políticas. Queda fuera de la regla de `outboundTcpCidrs` (es tráfico a la DB in-cluster, no al
+> relay del tenant): lo cubre la regla `namespaceSelector` de la NetworkPolicy meshed. **Si un
+> tenant usa Postgres externo con `5432` en `openTcpPorts`, hay que sacarlo de una de las dos
+> listas** — el chart rechaza a propósito que un puerto esté en ambas.
 - **repoSsh** (default `true`) — agrega los CIDR de GitHub (`repoSshCidrs`, rangos "git" de
   `api.github.com/meta`) a la NetworkPolicy **solo en el puerto 22**. **Solo surte efecto con
   `adhoc.devMode=true`** (es no-op en prod → ahí git-SSH queda bloqueado igual). Con `devMode` abre

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -126,7 +126,12 @@ Mailgun `2525`) queda excluido sin tener que editar `excludeOutboundPorts`:
   No se puede derivar de un hostname: usar el rango publicado del proveedor o la IP del relay.
 
 > **`5432` está en la lista por otro motivo: latencia, no server-first.** Postgres es el camino
-> más caliente de Odoo y cada salto por el sidecar agrega ~0,78 ms por consulta; el pod CNPG no
+> más caliente de Odoo y cada salto por el sidecar agrega **~0,15 ms por consulta** — medido con
+> un A/B entre bases con el puerto excluido y bases con el puerto aún interceptado, normalizando
+> la latencia de red con una sonda al puerto 22 (que ya estaba excluido). A ~126 consultas/s son
+> ~2 h de espera acumulada cada 108 h. ⚠️ **No medir esto durante una ventana de CPU throttling
+> del propio Postgres**: el congelamiento del backend infla el `SELECT 1` y se atribuye al proxy
+> latencia que es del motor (nos pasó: 0,85 ms aparentes contra 0,13 ms reales). El pod CNPG no
 > está en el mesh, así que el passthrough no aportaba mTLS ni políticas. Queda fuera de la regla
 > de `outboundTcpCidrs` (es tráfico a la DB in-cluster, no al relay del tenant): lo cubre la
 > regla `namespaceSelector` de la NetworkPolicy meshed. **Si un tenant usa Postgres externo con


### PR DESCRIPTION
Corrige la cifra que documentó #123. **No cambia comportamiento** — solo comentarios y documentación.

## Qué pasó

El `~0,78 ms por consulta` de #123 se midió sobre una base productiva **durante su ventana de CPU throttling de Postgres**. El congelamiento del backend infla el `SELECT 1`, y esa latencia —que es del motor— se le atribuyó al proxy. La misma base, medida fuera del pico, da `SELECT 1` p50 de 0,480 ms en lugar de 1,219 ms.

## La medición correcta

A/B entre bases con el puerto ya excluido y bases con el puerto todavía interceptado, normalizando la latencia de red con una sonda al puerto 22 (excluido del sidecar en ambos grupos):

| Grupo | delta (`SELECT 1` − red) |
| --- | --- |
| Chart viejo — 5432 por Envoy (3 bases) | 0,150 / 0,156 / 0,137 ms |
| Chart nuevo — 5432 excluido (3 bases) | −0,001 / 0,050 / −0,074 ms |
| Producción con sidecar (2 bases) | 0,132 / 0,141 ms |

Ruido del método ~±0,08 ms (de ahí los deltas negativos), pero la separación entre grupos es consistente en las 8 mediciones.

**Overhead real: ~0,15 ms por consulta.** A ~126 consultas/s son ~2 h de espera acumulada cada 108 h, no las ~13 h que decía #123.

## Qué se mantiene

El A/B confirma que **la exclusión hace lo que tiene que hacer**: el overhead desaparece en el grupo nuevo. El cambio de #123 es correcto y la mejora es real — solo que modesta. El cuello de botella de esas bases es el throttling del propio Postgres, no el proxy.

## Test plan

- `helm lint` + `helm template` en verde; pre-commit (`yamllint`, `helm validate charts`) en verde.
- Sin cambios de comportamiento: el diff toca únicamente comentarios y `doc/adhoc-odoo.md`.
- Se documenta el pitfall de medición en la doc para que no se repita.