### PR TITLE
fix: runAsUser numérico en auth-proxy de adhoc-way-instance

### DIFF
--- a/charts/adhoc-way-instance/templates/deployment.yaml
+++ b/charts/adhoc-way-instance/templates/deployment.yaml
@@ -74,8 +74,13 @@ spec:
             {{- toYaml .Values.authProxy.resources | nindent 12 }}
           securityContext:
             runAsNonRoot: true
+            # numeric uid so kubelet can verify non-root (the image's user is a
+            # non-numeric name, which fails runAsNonRoot with CreateContainerConfigError)
+            runAsUser: 65532
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop: ["ALL"]
         # --- tool: listens on 127.0.0.1, no port in the Service ---


### PR DESCRIPTION
## Qué

El container `auth-proxy` del chart `adhoc-way-instance` fija `runAsNonRoot: true` pero **sin `runAsUser` numérico**.

## Por qué

La imagen del proxy es distroless y declara el user como nombre (`nonroot`, no numérico). Con `runAsNonRoot: true` y sin `runAsUser`, kubelet no puede verificar que el user no es root → el pod queda en **`CreateContainerConfigError`** (1/2: el `auth-proxy` nunca arranca; el `tool` sí). Detectado desplegando una instancia real en cluster01.

## Fix

Se agrega al securityContext del `auth-proxy`:
- `runAsUser: 65532` (uid de `nonroot`)
- `seccompProfile: RuntimeDefault`

En paridad con `adhoc-way-platform` (que lo pone a nivel pod y por eso no tenía el bug). No toca el container `tool` (cada herramienta trae su propio user). Sin bump de versión: nada desplegado aún.

## Prueba

`helm upgrade` con el fix → pod **2/2 Running** → flujo de auth e2e completo OK (deny → grant → cookie → tool → replay bloqueado) atravesando el gateway Istio real.