### PR TITLE
feat: defaults de openCode en adhoc-way-instance (host + user)

### DIFF
--- a/charts/adhoc-way-instance/readme.md
+++ b/charts/adhoc-way-instance/readme.md
@@ -12,26 +12,32 @@ namespace.
 
 ## Install (one per user, release = host prefix)
 
+The chart defaults run **openCode**, so the orchestrator passes only the host and
+the owning user:
+
 ```sh
 helm install <prefix> charts/adhoc-way-instance -n <ns> \
   --set host=<prefix>.<platform-domain> \
-  --set tool.image.tag=<tool-image-tag> \
-  --set tool.port=<tool-port> \
-  --set user.id=<user-id>
+  --set user.id=<user-id> --set user.email=<user-email>
 ```
 
-> The `tool` **must** listen on `127.0.0.1` (anti-bypass): its port is not exposed
-> in the Service, only the sidecar reaches it. Configure its bind via
-> `tool.command` / `tool.args` / `tool.env`.
+The tool image/port/env and its public-URL env (`OPENCODE_PUBLIC_URL`, derived
+from `host`) are preset. Override `tool.*` to run a different tool.
+
+> Only the auth-proxy is exposed in the Service; the tool is reached over
+> `127.0.0.1` inside the pod. Prefer a tool that binds loopback (anti-bypass) —
+> either way the Service + NetworkPolicy keep the tool off the network.
 
 ## Main values
 
 | Key | Default | Description |
 |---|---|---|
 | `host` | `""` (required) | pod FQDN, `<prefix>.<platform-domain>` |
-| `tool.image.tag` | `openCodeServer-latest` | tool image |
-| `tool.port` | `3000` | tool localhost port |
-| `authProxy.image.tag` | `adhocwayAuthProxy-2026.08.04.1` | sidecar image |
+| `user.id` / `user.email` | `""` | owning user (annotations) |
+| `tool.image.tag` | `open-code-server-20260701-1` | tool image (default: openCode) |
+| `tool.port` | `4096` | tool localhost port |
+| `tool.publicUrlEnvVar` | `OPENCODE_PUBLIC_URL` | env for the tool's public URL (`https://<host>`); `""` to skip |
+| `authProxy.maxEntryTtl` | `10m` | max entry-token lifetime the proxy accepts |
 | `authProxy.entryPubKeyConfigMap` | `adhoc-way-platform-entry-pubkey` | platform ConfigMap |
 | `ingress.istio.gateway` | `adhoc-way-platform-gateway` | platform Gateway |
 
@@ -41,7 +47,7 @@ An orchestrator (an Odoo module) manages the lifecycle. Three hook points:
 
 ### 1. Activate (create the pod)
 
-`helm install <prefix> adhoc-way-instance -n <ns> --set host=... --set tool.image...=... --set user...`
+`helm install <prefix> adhoc-way-instance -n <ns> --set host=... --set user.id=... --set user.email=...`
 — or the equivalent via the Kubernetes API. The pod is dedicated to a single user.
 
 ### 2. Enter (authorize the user)
@@ -55,8 +61,11 @@ An orchestrator (an Odoo module) manages the lifecycle. Three hook points:
    {"user_id": "<id>", "email": "<email>", "host": "<host>"}
    ```
    `200` → `{ "token", "entry_url", "expires_at" }`
-2. Redirect the user's browser to `entry_url` (`https://<host>/_auth?token=...`).
-   The sidecar exchanges the single-use token (~60s) for the session cookie.
+2. Wait until the pod is routable — poll the unauthenticated `GET https://<host>/healthz`
+   (`503` while provisioning → `200` when ready). The poll never touches the token.
+3. Redirect the user's browser to `entry_url` (`https://<host>/_auth?token=...`).
+   The sidecar exchanges the single-use, short-lived token (bounded by
+   `authProxy.maxEntryTtl`) for the session cookie.
 
 Full `/grant` contract and errors: see `adhocwayAuthSvc` in `ingadhoc/devops-ops-tools`.
 
@@ -68,5 +77,5 @@ Full `/grant` contract and errors: see `adhocwayAuthSvc` in `ingadhoc/devops-ops
 
 - The grant token is the same bearer as the platform Secret; keep it server-side (never expose it to the browser).
 - `/grant` only signs for hosts under the configured suffix — validate the prefix on the caller side too.
-- Immediate revocation = destroy the instance. The entry token's short `exp` (~60s) is the safety net.
+- Immediate revocation = destroy the instance. The entry token's short `exp` is the safety net.
 - One pod = one user: the token's `aud == host` guarantees a token from another instance will not work here.

--- a/charts/adhoc-way-instance/readme.md
+++ b/charts/adhoc-way-instance/readme.md
@@ -7,7 +7,7 @@ namespace.
 
 ## What it installs
 
-- Deployment with **2 containers**: `auth-proxy` (the only exposed port) + `tool` (listens on `127.0.0.1`).
+- Deployment with **2 containers**: `auth-proxy` (the only exposed port) + `tool` (reached only over loopback inside the pod; no Service port).
 - Service (only the proxy port) · Istio VirtualService (`{host}` → platform gateway) · NetworkPolicy.
 
 ## Install (one per user, release = host prefix)

--- a/charts/adhoc-way-instance/templates/deployment.yaml
+++ b/charts/adhoc-way-instance/templates/deployment.yaml
@@ -95,12 +95,12 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.tool.publicUrlEnvVar .Values.tool.env }}
+          {{- if or (and .Values.tool.publicUrlEnvVar .Values.host) .Values.tool.env }}
           env:
-            {{- if .Values.tool.publicUrlEnvVar }}
+            {{- if and .Values.tool.publicUrlEnvVar .Values.host }}
             # The tool's own public URL, derived from host (e.g. openCode's OAuth/web).
-            - name: {{ .Values.tool.publicUrlEnvVar }}
-              value: "https://{{ .Values.host }}"
+            - name: {{ .Values.tool.publicUrlEnvVar | quote }}
+              value: {{ printf "https://%s" .Values.host | quote }}
             {{- end }}
             {{- with .Values.tool.env }}
             {{- toYaml . | nindent 12 }}

--- a/charts/adhoc-way-instance/templates/deployment.yaml
+++ b/charts/adhoc-way-instance/templates/deployment.yaml
@@ -95,9 +95,16 @@ spec:
           args:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.tool.env }}
+          {{- if or .Values.tool.publicUrlEnvVar .Values.tool.env }}
           env:
+            {{- if .Values.tool.publicUrlEnvVar }}
+            # The tool's own public URL, derived from host (e.g. openCode's OAuth/web).
+            - name: {{ .Values.tool.publicUrlEnvVar }}
+              value: "https://{{ .Values.host }}"
+            {{- end }}
+            {{- with .Values.tool.env }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.tool.volumeMounts }}
           volumeMounts:

--- a/charts/adhoc-way-instance/values.yaml
+++ b/charts/adhoc-way-instance/values.yaml
@@ -10,29 +10,41 @@ user:
   email: ""
 
 # --- The third-party web tool that runs in the pod ---
-# It MUST listen on 127.0.0.1 (anti-bypass): its port is not exposed in the
-# Service, only the auth-proxy sidecar reaches it inside the pod.
+# Only the auth-proxy sidecar is exposed in the Service; the tool is reached over
+# 127.0.0.1 inside the pod. It should listen on the configured `port` (ideally on
+# 127.0.0.1 for anti-bypass; the default tool, openCode, binds 0.0.0.0, so the
+# Service + NetworkPolicy are the enforced boundary).
+# Defaults below run openCode; override tool.* for a different tool.
 tool:
   image:
     repository: docker.io/adhoc/ops-tools
-    tag: openCodeServer-latest
+    tag: open-code-server-20260701-1
     # digest: pin to an exact image (overrides tag). Format: sha256:<hash>
     digest: ""
     pullPolicy: Always
   # Port the tool listens on (localhost).
-  port: 3000
+  port: 4096
+  # Env var name to receive the tool's own public URL, injected as https://<host>.
+  # openCode needs it (OPENCODE_PUBLIC_URL) for its web/OAuth flows behind a proxy.
+  # Set to "" for tools that don't need it.
+  publicUrlEnvVar: OPENCODE_PUBLIC_URL
   command: []
   args: []
-  env: []
+  # Defaults for openCode. OPENCODE_CONTAINER_PORT must match `port`.
+  env:
+    - name: OPENCODE_CONTAINER_PORT
+      value: "4096"
+    - name: OPENCODE_BUNDLES
+      value: ""
   volumeMounts: []
   securityContext: {}
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 100m
+      memory: 256Mi
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 2Gi
 
 # --- Authentication sidecar (adhocwayAuthProxy) ---
 authProxy:
@@ -44,7 +56,9 @@ authProxy:
   listenPort: 8080
   cookieName: way_session
   sessionTtl: 12h
-  maxEntryTtl: 5m
+  # Max lifetime the proxy accepts on an entry token. Kept above the signer's
+  # entryTtl (5m) so a freshly-minted token always validates (provisioning wait).
+  maxEntryTtl: 10m
   # ConfigMap (same namespace) with the signer Ed25519 public key.
   # Created by adhoc-way-platform.
   entryPubKeyConfigMap: adhoc-way-platform-entry-pubkey


### PR DESCRIPTION
## Qué

Hace que el orquestador (módulo Odoo) instale una instance pasando **solo `host` + `user`** — todo lo demás son defaults del chart, con **openCode** como tool por defecto.

## Cambios

- `tool.image.tag`: `openCodeServer-latest` → **`open-code-server-20260701-1`**. El tag anterior **no existía** en el registry (los reales son `open-code-server-<fecha>`) → el pull fallaba.
- `tool.port`: `3000` → **`4096`** (puerto de openCode).
- `tool.env`: defaults `OPENCODE_CONTAINER_PORT=4096` + `OPENCODE_BUNDLES=""`.
- `tool.publicUrlEnvVar` (nuevo, default `OPENCODE_PUBLIC_URL`): el template inyecta ese env = `https://<host>` (derivado del host, no se puede como default estático). openCode lo necesita para su web/OAuth detrás de proxy. `""` lo desactiva para otras tools.
- `authProxy.maxEntryTtl`: `5m` → **`10m`** (headroom sobre el `entryTtl` del signer, que pasa a 5m, para que un token recién minteado valide durante el provisioning).
- Más memoria para openCode (req 256Mi, lim 2Gi).

## Resultado

```sh
helm install <prefix> adhoc-way-instance -n way \
  --set host=<prefix>.<domain> --set user.id=<uid> --set user.email=<email>
```

`helm template` con solo host+user rinde la imagen real de openCode + `OPENCODE_PUBLIC_URL=https://<host>` derivado. `helm lint` + hook `lint-and-template` verdes.

Para otra tool: override de `tool.*` (image/port/env/publicUrlEnvVar).