### PR TITLE
chore: bump adhoc-way-instance 0.1.0 -> 0.1.1

### DIFF
--- a/charts/adhoc-way-instance/Chart.yaml
+++ b/charts/adhoc-way-instance/Chart.yaml
@@ -9,7 +9,7 @@ description: >
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
 appVersion: "adhocwayAuthProxy-2026.08.04.1"
 


### PR DESCRIPTION
## Por qué

`chart-releaser` solo publica **versiones nuevas**. Los cambios de #126 (runAsUser) y #127 (defaults de openCode: host+user, tag real, `OPENCODE_PUBLIC_URL` derivado, `maxEntryTtl` 10m) se mergearon a `main` pero el chart **publicado** seguía siendo el `0.1.0` viejo (tag `openCodeServer-latest` inexistente, `port 3000`, sin `publicUrlEnvVar`). Verificado con `helm show values adhoc-dev/adhoc-way-instance`.

## Qué

Bump `version: 0.1.0 → 0.1.1` en `Chart.yaml`. Al mergear, chart-releaser publica el `0.1.1` con todo lo acumulado, y vib puede `helm install adhoc-dev/adhoc-way-instance` (>= 0.1.1) con solo `host` + `user`.

Sin cambios de contenido — solo la versión.