### PR TITLE
feat: ruta interna opcional del auth-svc en adhoc-way-platform

### DIFF
--- a/charts/adhoc-way-platform/Chart.yaml
+++ b/charts/adhoc-way-platform/Chart.yaml
@@ -10,7 +10,7 @@ description: >
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 
 appVersion: "adhocwayAuthSvc-2026.08.04.1"
 

--- a/charts/adhoc-way-platform/ci/test-values.yaml
+++ b/charts/adhoc-way-platform/ci/test-values.yaml
@@ -1,6 +1,7 @@
 # Minimal values for `helm lint` / `helm template` (not real secrets).
 entryPubKey: "TEST_ENTRY_PUBKEY_BASE64=="
 authSvc:
+  internalHost: auth.way.example.com
   secret:
     signingKey: "TEST_SIGNING_KEY_BASE64=="
     grantToken: "test-grant-token"

--- a/charts/adhoc-way-platform/readme.md
+++ b/charts/adhoc-way-platform/readme.md
@@ -12,6 +12,9 @@ instances are deployed by [`adhoc-way-instance`](../adhoc-way-instance).
 - ConfigMap `adhoc-way-platform-entry-pubkey` — the public key consumed by the sidecars.
 - Istio Gateway for `*.<domain>` (binds to the ingress gateway).
 - cert-manager Certificate (wildcard) — TLS secret in `istio-system`.
+- Optional (`authSvc.internalHost`): an Istio Gateway + VirtualService on the **internal**
+  gateway, so in-VPC callers can `POST /grant` over HTTPS (still bearer-gated) without a
+  port-forward. Reuses the wildcard certificate.
 
 ## Bootstrap (once)
 

--- a/charts/adhoc-way-platform/templates/authsvc-internal-route.yaml
+++ b/charts/adhoc-way-platform/templates/authsvc-internal-route.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.authSvc.internalHost }}
+# Publishes the signer on the cluster's internal gateway. Reachable only from inside the
+# VPC (not the public internet), and still gated by the /grant bearer. Lets an in-VPC Odoo
+# orchestrator POST /grant over HTTPS instead of a port-forward. Reuses the platform's
+# wildcard certificate, which covers auth.<domain>.
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ include "adhoc-way-platform.fullname" . }}-authsvc-internal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- toYaml .Values.authSvc.internalIstioSelector | nindent 4 }}
+  servers:
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: {{ .Values.gateway.credentialName | quote }}
+        minProtocolVersion: TLSV1_2
+      hosts:
+        - {{ .Values.authSvc.internalHost | quote }}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "adhoc-way-platform.fullname" . }}-authsvc-internal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "adhoc-way-platform.labels" . | nindent 4 }}
+spec:
+  hosts:
+    - {{ .Values.authSvc.internalHost | quote }}
+  gateways:
+    - {{ include "adhoc-way-platform.fullname" . }}-authsvc-internal
+  http:
+    - route:
+        - destination:
+            host: {{ printf "%s.%s.svc.cluster.local" (include "adhoc-way-platform.fullname" .) .Release.Namespace }}
+            port:
+              number: {{ .Values.authSvc.listenPort }}
+{{- end }}

--- a/charts/adhoc-way-platform/values.yaml
+++ b/charts/adhoc-way-platform/values.yaml
@@ -21,6 +21,12 @@ authSvc:
   entryTtl: 60s
   # Only sign entry tokens for hosts under this suffix; set it to match `domain`.
   hostSuffix: .way.example.com
+  # Publish the signer on the cluster's internal gateway so in-VPC callers (the Odoo
+  # orchestrator) can POST /grant over HTTPS without a port-forward. Empty disables it;
+  # the host must be covered by the platform certificate (e.g. auth.<domain>).
+  internalHost: ""
+  internalIstioSelector:
+    istio: internal-ingressgateway
   # Secret holding the signing key (Ed25519) and the grant token. If
   # existingSecret is set it is used (recommended in prod). Otherwise the chart
   # creates one from `secret` (dev only).


### PR DESCRIPTION
## Qué

Con `authSvc.internalHost` seteado, el chart publica el signer (`adhocwayAuthSvc`) en el **gateway interno** del cluster: un `Gateway` (selector `internal-ingressgateway`) + `VirtualService` para ese host → Service `adhoc-way-platform:8090`. Reusa el certificado wildcard (`*.<domain>` cubre `auth.<domain>`).

## Por qué

El orquestador Odoo (`adhocway`) corre **dentro de la VPC** en prod y necesita `POST /grant` para minar el entry token. Sin esta ruta, al estar Odoo fuera del cluster (llega por Connect Gateway, que es API-only, no red de VPC) la única vía es un port-forward sobre el API. Publicando el signer en el gateway **interno**:
- Odoo hace un `POST` HTTPS directo al host interno (sin túnel).
- Queda accesible **solo desde la VPC** (cluster01 + cluster02), no del internet público.
- Sigue **gateado por el bearer** de `/grant`.

El módulo Odoo usa esta URL cuando está configurada y **cae automáticamente al port-forward** cuando no es alcanzable (p. ej. un devcontainer local fuera de la VPC).

## Notas

- `internalHost` vacío = ruta desactivada (default; el chart público queda genérico). El host real va en los values de Pulumi.
- Bump `0.1.0 → 0.1.1` (chart-releaser solo publica versiones nuevas).
- `helm lint` + hook `lint-and-template` verdes; bare template (sin `internalHost`) no renderiza la ruta.