### PR TITLE
feat: chequear que los selectores del chart matcheen labels que el chart emite

### DIFF
--- a/scripts/helm-check-selectors.py
+++ b/scripts/helm-check-selectors.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
-"""Verifica que todo selector de pods del chart matchee labels que el chart emite.
+"""Verifica que todo selector del chart matchee algo que el chart emite.
 
 Lee un render de `helm template` por stdin y falla si algún selector no puede
-matchear ningún pod producido por ese mismo chart. Un selector así no rompe el
-deploy — simplemente no selecciona nada, y el recurso queda inerte.
+matchear ningún pod (o Service) producido por ese mismo chart. Un selector así no
+rompe el deploy — simplemente no selecciona nada, y el recurso queda inerte.
 
 Motivación: dos NetworkPolicies del chart adhoc-odoo quedaron huérfanas porque su
 selector se armó con el helper de NOMBRE (`adhoc-odoo.fullname` -> "<release>-adhoc-odoo")
 en vez del de SELECCIÓN (`.Release.Name`). No seleccionaban ningún pod, así que no
 protegían nada, y eso pasó desapercibido en las 327 bases de la flota.
 
-Valida el selector que define A QUIÉN aplica un recurso. Los podSelector dentro de
-las reglas from/to de una NetworkPolicy quedan fuera a propósito: pueden apuntar
-legítimamente a pods de otros charts, y validarlos daría falsos positivos.
+Alcance deliberado:
+- Valida el selector que define A QUIÉN aplica un recurso. Los podSelector dentro de
+  las reglas from/to de una NetworkPolicy quedan fuera: pueden apuntar legítimamente a
+  pods de otros charts y darían falsos positivos.
+- Se reconocen los controladores que este repo usa. Un chart que renderice pods vía un
+  CRD de terceros (Argo Rollout, DeploymentConfig, Knative) no aporta sus labels y sus
+  selectores darían falso positivo; sumar el kind acá es el arreglo.
 """
 
 import sys
@@ -20,23 +24,48 @@ import sys
 import yaml
 
 # Workloads cuyo pod template describe los labels que van a tener los pods.
-POD_TEMPLATE_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"}
+POD_TEMPLATE_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet", "ReplicationController"}
 
-# Dónde vive el selector que define a qué pods aplica cada recurso.
-SELECTOR_PATHS = {
+# Selector que define a qué pods aplica cada recurso.
+POD_SELECTOR_PATHS = {
     "Service": ("spec", "selector"),
-    "Deployment": ("spec", "selector", "matchLabels"),
-    "StatefulSet": ("spec", "selector", "matchLabels"),
-    "DaemonSet": ("spec", "selector", "matchLabels"),
-    "PodDisruptionBudget": ("spec", "selector", "matchLabels"),
-    "NetworkPolicy": ("spec", "podSelector", "matchLabels"),
-    "PodMonitor": ("spec", "selector", "matchLabels"),
-    "ServiceMonitor": ("spec", "selector", "matchLabels"),
+    "Deployment": ("spec", "selector"),
+    "StatefulSet": ("spec", "selector"),
+    "DaemonSet": ("spec", "selector"),
+    "ReplicationController": ("spec", "selector"),
+    "PodDisruptionBudget": ("spec", "selector"),
+    "NetworkPolicy": ("spec", "podSelector"),
+    "PodMonitor": ("spec", "selector"),
 }
+
+# ServiceMonitor selecciona Services, no pods: se compara contra otro pool.
+SERVICE_SELECTOR_PATHS = {"ServiceMonitor": ("spec", "selector")}
+
+# Selectores que Kubernetes acepta como mapa plano, sin matchLabels/matchExpressions.
+FLAT_SELECTOR_KINDS = {"Service", "ReplicationController"}
+
+# Labels que inyecta el runtime (no el chart): no se pueden validar contra el render.
+RUNTIME_INJECTED_EXACT = {
+    "pod-template-hash",
+    "controller-revision-hash",
+    "statefulset.kubernetes.io/pod-name",
+    "apps.kubernetes.io/pod-index",
+    "job-name",
+    "controller-uid",
+}
+RUNTIME_INJECTED_PREFIXES = (
+    "security.istio.io/",  # tlsMode, lo pone el sidecar injector
+    "service.istio.io/",  # canonical-name / canonical-revision
+    "batch.kubernetes.io/",  # job-name, controller-uid
+)
+
+
+def is_runtime_injected(key):
+    return key in RUNTIME_INJECTED_EXACT or key.startswith(RUNTIME_INJECTED_PREFIXES)
 
 
 def dig(doc, path):
-    """Devuelve doc[path[0]][path[1]]... o None si algún tramo falta."""
+    """Devuelve doc[path[0]][path[1]]... o None si algún tramo falta o no es dict."""
     cur = doc
     for key in path:
         if not isinstance(cur, dict):
@@ -45,53 +74,119 @@ def dig(doc, path):
     return cur
 
 
-def emitted_label_sets(docs):
-    """Conjuntos de labels que van a tener los pods que este chart produce."""
+def as_label_map(raw):
+    """Normaliza a {str: str}. Devuelve None si no es un mapa de labels válido."""
+    if not isinstance(raw, dict):
+        return None
+    return {str(k): str(v) for k, v in raw.items()}
+
+
+def parse_selector(doc, kind, path):
+    """Devuelve (matchLabels, matchExpressions) o None si el selector está vacío."""
+    raw = dig(doc, path)
+    if not isinstance(raw, dict) or not raw:
+        return None
+    if kind in FLAT_SELECTOR_KINDS:
+        labels = as_label_map(raw)
+        return (labels, []) if labels else None
+    labels = as_label_map(raw.get("matchLabels")) or {}
+    exprs = raw.get("matchExpressions")
+    exprs = exprs if isinstance(exprs, list) else []
+    if not labels and not exprs:
+        return None
+    return labels, exprs
+
+
+def satisfies(labels, match_labels, match_expressions):
+    """True si el conjunto de labels satisface el selector."""
+    for key, value in match_labels.items():
+        if is_runtime_injected(key):
+            continue
+        if labels.get(key) != value:
+            return False
+    for expr in match_expressions:
+        if not isinstance(expr, dict):
+            continue
+        key = str(expr.get("key", ""))
+        if not key or is_runtime_injected(key):
+            continue
+        operator = expr.get("operator")
+        values = [str(v) for v in (expr.get("values") or [])]
+        present = key in labels
+        if operator == "In" and (not present or labels[key] not in values):
+            return False
+        if operator == "NotIn" and present and labels[key] in values:
+            return False
+        if operator == "Exists" and not present:
+            return False
+        if operator == "DoesNotExist" and present:
+            return False
+    return True
+
+
+def cnpg_label_sets(doc):
+    """Los pods de CNPG no están en el render: los crea el operador.
+
+    Se derivan del Cluster: inheritedMetadata más los cnpg.io/* que el operador arma
+    con su nombre. Se emiten primary y replica porque un selector hacia réplicas es
+    igual de legítimo.
+    """
+    name = dig(doc, ("metadata", "name"))
+    inherited = as_label_map(dig(doc, ("spec", "inheritedMetadata", "labels"))) or {}
     sets = []
-    for doc in docs:
-        kind = doc.get("kind")
-        if kind in POD_TEMPLATE_KINDS:
-            labels = dig(doc, ("spec", "template", "metadata", "labels"))
-            if labels:
-                sets.append((f"{kind}/{dig(doc, ('metadata', 'name'))}", dict(labels)))
-        elif kind == "CronJob":
-            labels = dig(doc, ("spec", "jobTemplate", "spec", "template", "metadata", "labels"))
-            if labels:
-                sets.append((f"CronJob/{dig(doc, ('metadata', 'name'))}", dict(labels)))
-        elif kind == "Pod":
-            labels = dig(doc, ("metadata", "labels"))
-            if labels:
-                sets.append((f"Pod/{dig(doc, ('metadata', 'name'))}", dict(labels)))
-        elif kind == "Cluster" and "postgresql.cnpg.io" in str(doc.get("apiVersion", "")):
-            # Los pods de CNPG no están en el render: los crea el operador. Sus labels
-            # son los de inheritedMetadata más los que el operador deriva del Cluster.
-            name = dig(doc, ("metadata", "name"))
-            labels = dict(dig(doc, ("spec", "inheritedMetadata", "labels")) or {})
-            labels.update(
-                {
-                    "cnpg.io/cluster": name,
-                    "cnpg.io/podRole": "instance",
-                    "cnpg.io/instanceRole": "primary",
-                    "role": "primary",
-                }
-            )
-            sets.append((f"Cluster/{name} (pods vía operador CNPG)", labels))
+    for role in ("primary", "replica"):
+        labels = dict(inherited)
+        labels.update(
+            {
+                "cnpg.io/cluster": str(name),
+                "cnpg.io/podRole": "instance",
+                "cnpg.io/instanceRole": role,
+                "role": role,
+            }
+        )
+        sets.append((f"Cluster/{name} ({role}, pods vía operador CNPG)", labels))
     return sets
 
 
+def collect_pools(docs):
+    """Conjuntos de labels de pods y de Services que este chart produce."""
+    pods, services = [], []
+    for doc in docs:
+        kind = doc.get("kind")
+        name = dig(doc, ("metadata", "name"))
+        if kind in POD_TEMPLATE_KINDS:
+            labels = as_label_map(dig(doc, ("spec", "template", "metadata", "labels")))
+            if labels:
+                pods.append((f"{kind}/{name}", labels))
+        elif kind == "CronJob":
+            labels = as_label_map(dig(doc, ("spec", "jobTemplate", "spec", "template", "metadata", "labels")))
+            if labels:
+                pods.append((f"CronJob/{name}", labels))
+        elif kind == "Pod":
+            labels = as_label_map(dig(doc, ("metadata", "labels")))
+            if labels:
+                pods.append((f"Pod/{name}", labels))
+        elif kind == "Cluster" and "postgresql.cnpg.io" in str(doc.get("apiVersion", "")):
+            pods.extend(cnpg_label_sets(doc))
+        if kind == "Service":
+            labels = as_label_map(dig(doc, ("metadata", "labels")))
+            if labels:
+                services.append((f"Service/{name}", labels))
+    return pods, services
+
+
 def collect_selectors(docs):
-    """Selectores que definen a qué pods aplica cada recurso."""
+    """(kind, nombre, matchLabels, matchExpressions, pool) por cada selector."""
     found = []
     for doc in docs:
         kind = doc.get("kind")
-        path = SELECTOR_PATHS.get(kind)
-        if not path:
-            continue
-        selector = dig(doc, path)
-        # Selector vacío o ausente: matchea todo o el recurso no selecciona pods.
-        if not selector:
-            continue
-        found.append((kind, dig(doc, ("metadata", "name")), dict(selector)))
+        for paths, pool in ((POD_SELECTOR_PATHS, "pods"), (SERVICE_SELECTOR_PATHS, "services")):
+            path = paths.get(kind)
+            if not path:
+                continue
+            parsed = parse_selector(doc, kind, path)
+            if parsed:
+                found.append((kind, dig(doc, ("metadata", "name")), parsed[0], parsed[1], pool))
     return found
 
 
@@ -102,33 +197,37 @@ def main():
         print(f"ERROR: no se pudo parsear el render de helm: {exc}", file=sys.stderr)
         return 2
 
-    label_sets = emitted_label_sets(docs)
-    if not label_sets:
+    pods, services = collect_pools(docs)
+    if not pods and not services:
         return 0
 
     failures = []
-    for kind, name, selector in collect_selectors(docs):
-        matched = [
-            origin
-            for origin, labels in label_sets
-            if all(labels.get(k) == v for k, v in selector.items())
-        ]
-        if not matched:
-            failures.append((kind, name, selector))
+    for kind, name, match_labels, exprs, pool in collect_selectors(docs):
+        candidates = pods if pool == "pods" else services
+        # Sin nada del pool en el render no hay con qué comparar: no es evidencia de error.
+        if not candidates:
+            continue
+        if not any(satisfies(labels, match_labels, exprs) for _, labels in candidates):
+            failures.append((kind, name, match_labels, exprs, candidates, pool))
 
     if not failures:
         return 0
 
     print("", file=sys.stderr)
-    print("ERROR: hay selectores que no matchean ningún pod de este chart.", file=sys.stderr)
+    print("ERROR: hay selectores que no matchean nada de lo que emite este chart.", file=sys.stderr)
     print("Un recurso así no falla el deploy: queda inerte y no hace nada.", file=sys.stderr)
-    for kind, name, selector in failures:
-        print(f"\n  {kind}/{name}", file=sys.stderr)
-        print(f"    selector: {selector}", file=sys.stderr)
-        for key, value in selector.items():
-            candidates = sorted({labels[key] for _, labels in label_sets if key in labels})
-            if candidates and value not in candidates:
-                print(f"    '{key}': el chart emite {candidates}, no '{value}'", file=sys.stderr)
+    for kind, name, match_labels, exprs, candidates, pool in failures:
+        print(f"\n  {kind}/{name}  (selecciona {pool})", file=sys.stderr)
+        if match_labels:
+            print(f"    matchLabels: {match_labels}", file=sys.stderr)
+        if exprs:
+            print(f"    matchExpressions: {exprs}", file=sys.stderr)
+        for key, value in match_labels.items():
+            if is_runtime_injected(key):
+                continue
+            emitted = sorted({labels[key] for _, labels in candidates if key in labels})
+            if emitted and value not in emitted:
+                print(f"    '{key}': el chart emite {emitted}, no '{value}'", file=sys.stderr)
     print(
         "\nPista habitual: usar el helper de NOMBRE (fullname) donde va el de SELECCIÓN.",
         file=sys.stderr,

--- a/scripts/helm-check-selectors.py
+++ b/scripts/helm-check-selectors.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Verifica que todo selector de pods del chart matchee labels que el chart emite.
+
+Lee un render de `helm template` por stdin y falla si algún selector no puede
+matchear ningún pod producido por ese mismo chart. Un selector así no rompe el
+deploy — simplemente no selecciona nada, y el recurso queda inerte.
+
+Motivación: dos NetworkPolicies del chart adhoc-odoo quedaron huérfanas porque su
+selector se armó con el helper de NOMBRE (`adhoc-odoo.fullname` -> "<release>-adhoc-odoo")
+en vez del de SELECCIÓN (`.Release.Name`). No seleccionaban ningún pod, así que no
+protegían nada, y eso pasó desapercibido en las 327 bases de la flota.
+
+Valida el selector que define A QUIÉN aplica un recurso. Los podSelector dentro de
+las reglas from/to de una NetworkPolicy quedan fuera a propósito: pueden apuntar
+legítimamente a pods de otros charts, y validarlos daría falsos positivos.
+"""
+
+import sys
+
+import yaml
+
+# Workloads cuyo pod template describe los labels que van a tener los pods.
+POD_TEMPLATE_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "ReplicaSet"}
+
+# Dónde vive el selector que define a qué pods aplica cada recurso.
+SELECTOR_PATHS = {
+    "Service": ("spec", "selector"),
+    "Deployment": ("spec", "selector", "matchLabels"),
+    "StatefulSet": ("spec", "selector", "matchLabels"),
+    "DaemonSet": ("spec", "selector", "matchLabels"),
+    "PodDisruptionBudget": ("spec", "selector", "matchLabels"),
+    "NetworkPolicy": ("spec", "podSelector", "matchLabels"),
+    "PodMonitor": ("spec", "selector", "matchLabels"),
+    "ServiceMonitor": ("spec", "selector", "matchLabels"),
+}
+
+
+def dig(doc, path):
+    """Devuelve doc[path[0]][path[1]]... o None si algún tramo falta."""
+    cur = doc
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def emitted_label_sets(docs):
+    """Conjuntos de labels que van a tener los pods que este chart produce."""
+    sets = []
+    for doc in docs:
+        kind = doc.get("kind")
+        if kind in POD_TEMPLATE_KINDS:
+            labels = dig(doc, ("spec", "template", "metadata", "labels"))
+            if labels:
+                sets.append((f"{kind}/{dig(doc, ('metadata', 'name'))}", dict(labels)))
+        elif kind == "CronJob":
+            labels = dig(doc, ("spec", "jobTemplate", "spec", "template", "metadata", "labels"))
+            if labels:
+                sets.append((f"CronJob/{dig(doc, ('metadata', 'name'))}", dict(labels)))
+        elif kind == "Pod":
+            labels = dig(doc, ("metadata", "labels"))
+            if labels:
+                sets.append((f"Pod/{dig(doc, ('metadata', 'name'))}", dict(labels)))
+        elif kind == "Cluster" and "postgresql.cnpg.io" in str(doc.get("apiVersion", "")):
+            # Los pods de CNPG no están en el render: los crea el operador. Sus labels
+            # son los de inheritedMetadata más los que el operador deriva del Cluster.
+            name = dig(doc, ("metadata", "name"))
+            labels = dict(dig(doc, ("spec", "inheritedMetadata", "labels")) or {})
+            labels.update(
+                {
+                    "cnpg.io/cluster": name,
+                    "cnpg.io/podRole": "instance",
+                    "cnpg.io/instanceRole": "primary",
+                    "role": "primary",
+                }
+            )
+            sets.append((f"Cluster/{name} (pods vía operador CNPG)", labels))
+    return sets
+
+
+def collect_selectors(docs):
+    """Selectores que definen a qué pods aplica cada recurso."""
+    found = []
+    for doc in docs:
+        kind = doc.get("kind")
+        path = SELECTOR_PATHS.get(kind)
+        if not path:
+            continue
+        selector = dig(doc, path)
+        # Selector vacío o ausente: matchea todo o el recurso no selecciona pods.
+        if not selector:
+            continue
+        found.append((kind, dig(doc, ("metadata", "name")), dict(selector)))
+    return found
+
+
+def main():
+    try:
+        docs = [d for d in yaml.safe_load_all(sys.stdin.read()) if isinstance(d, dict)]
+    except yaml.YAMLError as exc:
+        print(f"ERROR: no se pudo parsear el render de helm: {exc}", file=sys.stderr)
+        return 2
+
+    label_sets = emitted_label_sets(docs)
+    if not label_sets:
+        return 0
+
+    failures = []
+    for kind, name, selector in collect_selectors(docs):
+        matched = [
+            origin
+            for origin, labels in label_sets
+            if all(labels.get(k) == v for k, v in selector.items())
+        ]
+        if not matched:
+            failures.append((kind, name, selector))
+
+    if not failures:
+        return 0
+
+    print("", file=sys.stderr)
+    print("ERROR: hay selectores que no matchean ningún pod de este chart.", file=sys.stderr)
+    print("Un recurso así no falla el deploy: queda inerte y no hace nada.", file=sys.stderr)
+    for kind, name, selector in failures:
+        print(f"\n  {kind}/{name}", file=sys.stderr)
+        print(f"    selector: {selector}", file=sys.stderr)
+        for key, value in selector.items():
+            candidates = sorted({labels[key] for _, labels in label_sets if key in labels})
+            if candidates and value not in candidates:
+                print(f"    '{key}': el chart emite {candidates}, no '{value}'", file=sys.stderr)
+    print(
+        "\nPista habitual: usar el helper de NOMBRE (fullname) donde va el de SELECCIÓN.",
+        file=sys.stderr,
+    )
+    print("Los selectores se arman con selectorLabels / .Release.Name.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/helm-validate-charts.sh
+++ b/scripts/helm-validate-charts.sh
@@ -72,13 +72,17 @@ fi
 echo "Charts a validar:" >&2
 printf ' - %s\n' "${charts[@]##$repo_root/}" >&2
 
+# Chequeo de selectores: corre sobre el render, no reemplaza a lint/template.
+check_selectors=("python3" "$repo_root/scripts/helm-check-selectors.py")
+fail=0
+
 for chart in "${charts[@]}"; do
   echo >&2
   echo "==> helm lint ${chart##$repo_root/}" >&2
   helm lint "$chart"
 
   echo "==> helm template ${chart##$repo_root/}" >&2
-  helm template "$chart" >/dev/null
+  helm template "$chart" | "${check_selectors[@]}" || fail=1
 
   # Fixtures de CI (convención chart-testing): cada ci/*-values.yaml es un set
   # de values que el chart debe renderizar sin error. Sirven como regresión de
@@ -87,7 +91,7 @@ for chart in "${charts[@]}"; do
     shopt -s nullglob
     for fixture in "$chart"/ci/*-values.yaml; do
       echo "==> helm template ${chart##$repo_root/} -f ${fixture##$repo_root/}" >&2
-      helm template "$chart" -f "$fixture" >/dev/null
+      helm template "$chart" -f "$fixture" | "${check_selectors[@]}" || fail=1
     done
     shopt -u nullglob
   fi
@@ -95,4 +99,8 @@ for chart in "${charts[@]}"; do
 done
 
 echo >&2
+if [[ "$fail" -ne 0 ]]; then
+  echo "FALLO: la validación de Helm encontró problemas." >&2
+  exit 1
+fi
 echo "OK: validación de Helm completada." >&2


### PR DESCRIPTION
## El problema

Un selector que no matchea ningún pod **no rompe el deploy**: el recurso queda inerte y no hace nada. Ni `helm lint` ni `helm template` lo detectan, y en review es muy fácil que pase.

Nos pasó con dos NetworkPolicies del chart `adhoc-odoo`, que quedaron huérfanas en **las 327 bases de la flota**: su selector se armó con el helper de **nombre** (`adhoc-odoo.fullname` → `<release>-adhoc-odoo`) en vez del de **selección** (`.Release.Name`). Ninguna de las dos protegía nada, y no había forma de notarlo salvo mirándolo a mano.

## Qué hace

`scripts/helm-check-selectors.py` corre sobre el render que `helm-validate-charts.sh` ya produce: junta los labels de cada pod template del chart y verifica que todo selector matchee al menos uno.

Los pods de CNPG no aparecen en el render (los crea el operador), así que se derivan del `Cluster`: `inheritedMetadata.labels` más los `cnpg.io/*` que el operador arma a partir de su nombre. Eso permite validar selectores contra la base, que era uno de los dos casos reales.

Salida cuando falla:

```
ERROR: hay selectores que no matchean ningún pod de este chart.
Un recurso así no falla el deploy: queda inerte y no hace nada.

  NetworkPolicy/allow-same-namespace
    selector: {'cnpg.io/cluster': 'release-name-adhoc-odoo-pg'}
    'cnpg.io/cluster': el chart emite ['release-name-pg'], no 'release-name-adhoc-odoo-pg'
```

## Alcance deliberado

Valida el selector que define **a quién aplica** cada recurso: `Service.spec.selector`, `spec.selector.matchLabels` de los workloads, PDB, NetworkPolicy (`spec.podSelector`), PodMonitor y ServiceMonitor.

Quedan fuera **a propósito** los `podSelector` dentro de las reglas `from`/`to` de una NetworkPolicy: pueden apuntar legítimamente a pods de otros charts y darían falsos positivos. También se ignoran los `matchExpressions`, que no se validan con este método (el chart usa uno con `DoesNotExist` que es correcto).

## Test plan

- **Los 14 charts del repo pasan** con sus values por defecto → este PR deja CI en verde.
- Verificado que **detecta los dos casos reales**: con un fixture que habilita `cloudNativePG` y `monitoring` (que los values default dejan apagados), reporta exactamente las dos NetworkPolicies y en cada una dice qué label emite el chart contra el que busca el selector.
- Ese fixture **no entra en este PR**: al exponer los dos bugs todavía sin arreglar, dejaría CI roja. Va junto con el fix de las policies, donde funciona como su test de regresión.
- `bash -n` sobre el shell y parseo del Python en verde; pre-commit en verde.