### PR TITLE
fix: excluir el pod de Postgres de los selectores de Odoo

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
+++ b/charts/adhoc-odoo/templates/odoo/podMonitoring.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "adhoc-odoo.selectorLabels" . | nindent 6 }}
+      # El pod de CNPG hereda los app.kubernetes.io/* del chart: sin esto entra al selector.
+      adhoc.ar/app-name: "odoo"
   podMetricsEndpoints:
   {{- if eq (include "adhoc-odoo.exporterSidecarEnabled" .) "true" }}
   - port: prom-odoo

--- a/charts/adhoc-odoo/templates/odoo/service.yaml
+++ b/charts/adhoc-odoo/templates/odoo/service.yaml
@@ -13,6 +13,8 @@ spec:
       name: http
   selector:
     {{- include "adhoc-odoo.selectorLabels" . | nindent 4 }}
+    # El pod de CNPG hereda los app.kubernetes.io/* del chart: sin esto entra al selector.
+    adhoc.ar/app-name: "odoo"
 ---
 {{- $usewebsocket  := .Values.odoo.performance.workers | toString | int -}}
 {{- if gt $usewebsocket 0 }}
@@ -31,4 +33,6 @@ spec:
       name: websocket
   selector:
     {{- include "adhoc-odoo.selectorLabels" . | nindent 4 }}
+    # El pod de CNPG hereda los app.kubernetes.io/* del chart: sin esto entra al selector.
+    adhoc.ar/app-name: "odoo"
 {{- end }}


### PR DESCRIPTION
## El problema

Los Services `-http` y `-websocket` y el PodMonitor de Odoo seleccionan por `app.kubernetes.io/{name,instance}`. **El pod de CNPG lleva esos mismos labels**: el chart se los pasa vía `Cluster.spec.inheritedMetadata.labels`, que incluye `adhoc-odoo.labels` y por lo tanto `selectorLabels`.

Resultado: los tres selectores matchean **3 pods** — los 2 de Odoo y la base de datos.

## Por qué no explota hoy

Por dos casualidades, ninguna de diseño:

- Los Services usan **named ports** (`http`, `websocket`) y el pod de Postgres declara `postgresql`/`metrics`/`status`, así que Kubernetes lo deja fuera de los endpoints.
- El PodMonitor apunta al port `prom-odoo`, que tampoco existe en la base.

Alcanza con que alguien cambie un `targetPort` a numérico para que el Postgres entre como endpoint de tráfico HTTP.

## El cambio

Agregar `adhoc.ar/app-name: "odoo"` a los tres selectores. No es un label nuevo: es el discriminador que el chart **ya usa** en el PDB de Odoo, en la NetworkPolicy de egress meshed y en la regla de afinidad del Deployment.

Antes y después, renderizando con `cloudNativePG` y `monitoring` habilitados:

```
ANTES                                       DESPUÉS
Service/rel-adhoc-odoo-http      -> odoo, PG    -> odoo
Service/rel-adhoc-odoo-websocket -> odoo, PG    -> odoo
PodMonitor/rel-adhoc-odoo-odoo   -> odoo, PG    -> odoo
```

## Por qué es seguro aplicarlo

`spec.selector` de un Service **es mutable** (a diferencia del de un Deployment), así que no hay que recrear nada.

El riesgo sería que algún pod de Odoo no tuviera el label y perdiera sus endpoints. Verificado sobre la flota: **576 pods de Odoo en ejecución entre cell01 y cell02, los 576 lo tienen.** Cero excepciones.

## Alcance

El selector del **Deployment** tiene exactamente el mismo problema y **no se toca acá**: `spec.selector` es inmutable y arreglarlo exige borrar y recrear el Deployment, o sea corte de servicio. Queda para una ventana coordinada. Este PR baja el riesgo sin disrupción.

## Test plan

- `helm lint` + `helm template` y el chequeo de selectores nuevo, en verde.
- Verificado con render que los tres recursos pasan de matchear `odoo + PG` a solo `odoo`, incluyendo el Service de websocket (que requiere `workers > 0` para renderizarse).
- Verificado en los dos clusters que ningún pod de Odoo queda fuera del selector nuevo.