### PR TITLE
docs: un 403 en lookup no es silencioso

### DIFF
--- a/charts/adhoc-way-instance/readme.md
+++ b/charts/adhoc-way-instance/readme.md
@@ -58,10 +58,19 @@ it, and `helm uninstall` of the surface that created it leaves it Bound.
 
 Four things worth knowing:
 
-- **The installing identity needs `get` on claims, not only `create`.** Helm's
-  `lookup` returns empty when it may not read — it does not fail — so a missing
-  permission looks exactly like "the claim is not there", and the create that
-  follows dies with an ownership error that never mentions permissions.
+- **The installing identity needs `get` on claims, not only `create`.** Without it
+  the install stops at render time — `lookup` propagates the 403 instead of
+  swallowing it, so the message names the permission, the service account and the
+  namespace:
+
+  ```
+  error calling lookup: persistentvolumeclaims "way-user-2" is forbidden:
+  User "system:serviceaccount:devops:helm-runner-ksa" cannot get resource
+  "persistentvolumeclaims" in API group "" in the namespace "way"
+  ```
+
+  Note it fails *before* creating anything, so a half-installed surface is not a
+  state you can end up in this way.
 - **`lookup` is blind without a cluster**, so `helm template` and `--dry-run`
   render the claim even when it already exists. What CI validates is not what gets
   applied.

--- a/charts/adhoc-way-instance/templates/pvc.yaml
+++ b/charts/adhoc-way-instance/templates/pvc.yaml
@@ -5,10 +5,9 @@ It is created here, by whichever surface of this user happens to be installed
 first, and then left alone: the claim is named after the USER, so the second
 surface finds it instead of making its own.
 
-`lookup` is what makes that work — and it is also the sharp edge. It returns
-empty when it is not allowed to read, instead of failing, so a missing `get`
-permission looks exactly like "the claim is not there" and the create that
-follows dies with an ownership error that never mentions permissions.
+`lookup` is what makes that work, and it needs `get` on claims — not just
+`create`. Without the permission the install stops here at render time, with a
+403 that names the service account and the namespace.
 */}}
 {{- if and .Values.state.persistent .Values.state.create }}
 {{- $claimName := include "adhoc-way-instance.claimName" . }}

--- a/charts/adhoc-way-instance/values.yaml
+++ b/charts/adhoc-way-instance/values.yaml
@@ -108,10 +108,9 @@ state:
   # Create the claim when it does not exist. Set to false to require that someone
   # provisioned it beforehand.
   #
-  # The identity running the install needs `get` on claims, not only `create`:
-  # Helm's lookup returns EMPTY when it may not read, instead of failing, so a
-  # missing permission looks exactly like "the claim is not there" and the create
-  # that follows dies with an ownership error that never mentions permissions.
+  # The identity running the install needs `get` on claims, not only `create`.
+  # Without it the install stops at render time with a message that names the
+  # permission and the service account — lookup propagates the 403.
   create: true
 
   size: 1Gi


### PR DESCRIPTION
Corrijo algo que documenté al revés en #131.

Escribí que `lookup` **devuelve vacío** cuando no tiene permiso de leer, y que por eso un permiso faltante se veía igual que "el disco no está" hasta explotar después con un error de ownership que no hablaba de permisos.

Al toparnos con el caso real, helm **propaga el 403 y corta el render**:

```
error calling lookup: persistentvolumeclaims "way-user-2" is forbidden:
User "system:serviceaccount:devops:helm-runner-ksa" cannot get resource
"persistentvolumeclaims" in API group "" in the namespace "way"
```

Nombra el permiso, el service account y el namespace, y falla **antes de crear nada** — así que por esta vía tampoco se llega a una superficie a medio instalar. Es bastante mejor de lo que había advertido.

El permiso sigue siendo lo que hay que tener (va en [devops-cloud-infra#71](https://github.com/ingadhoc/devops-cloud-infra/pull/71)); lo que cambia es que encontrarlo no cuesta nada.

Sin bump de versión: es sólo documentación y no necesita republicarse.