### PR TITLE
fix: excluir el pod de Postgres del selector del Deployment de Odoo

### DIFF
--- a/charts/adhoc-odoo/templates/odoo/deployment.yaml
+++ b/charts/adhoc-odoo/templates/odoo/deployment.yaml
@@ -27,6 +27,9 @@ spec:
   selector:
     matchLabels:
       {{- include "adhoc-odoo.selectorLabels" . | nindent 6 }}
+      # El pod de CNPG hereda los app.kubernetes.io/* del chart: sin esto entra al selector.
+      # OJO: spec.selector es inmutable — cambiarlo exige recrear el Deployment (ver doc).
+      adhoc.ar/app-name: "odoo"
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/doc/adhoc-odoo.md
+++ b/doc/adhoc-odoo.md
@@ -354,6 +354,35 @@ resources:
     memory: 250Mi
 ```
 
+## Cambiar el `spec.selector` del Deployment (campo inmutable)
+
+`spec.selector` de un Deployment **no se puede modificar**: un `helm upgrade` normal falla con
+`spec.selector: Invalid value: ... field is immutable` y **deja la release en `failed`**. Hay que
+recrear el Deployment, pero eso **no implica downtime** si se hace con `--cascade=orphan`:
+
+```bash
+# 1. Borra SOLO el objeto Deployment. El ReplicaSet y los pods siguen corriendo y sirviendo.
+kubectl -n <ns> delete deploy <release>-adhoc-odoo --cascade=orphan
+
+# 2. Helm lo recrea con el selector nuevo y ADOPTA el ReplicaSet que quedó huérfano.
+helm upgrade <release> <chart> -n <ns> --reuse-values --timeout 5m
+```
+
+La adopción funciona porque el `pod-template-hash` se calcula sobre el **pod template**, que no
+cambia: el Deployment nuevo llega al mismo hash, encuentra el ReplicaSet existente y lo toma. Los
+pods ni se enteran. Validado en `test-biomega-10-08-1`: mismo pod, `restartCount` 0, `startedAt`
+sin cambios, HTTP 200 durante todo el procedimiento, y sin pods duplicados.
+
+Tres condiciones que hay que respetar:
+
+- **El pod template no puede cambiar en el mismo upgrade.** Si cambia, el hash cambia, no hay
+  adopción y se hace un rolling update normal — que con `replicaCount: 1` sí produce un blip.
+  Conviene aislar este cambio en su propio upgrade.
+- **No intentar el `helm upgrade` normal primero.** Falla y deja la release en `failed`; el
+  procedimiento funciona igual después, pero ensucia el historial sin necesidad.
+- Entre el paso 1 y el 2 hay unos segundos **sin Deployment**: si justo ahí se cae un pod, nadie
+  lo recrea hasta el paso 2. Encadenar los dos comandos.
+
 ## Changelog reciente
 
 | Versión | Cambios principales |


### PR DESCRIPTION
Último de los selectores que matcheaban de más. Cierra el frente que abrieron #130, #132 y #133.

## Qué

El pod de CNPG hereda los `app.kubernetes.io/*` del chart vía `inheritedMetadata`, así que el selector del Deployment de Odoo también lo incluía. No tiene efecto observable —el ReplicaSet no adopta un pod que ya tiene `ownerReference` al `Cluster`— pero el selector afirmaba algo que no era cierto, y esa clase de mentira es la que produjo los otros tres casos.

## Requiere un procedimiento especial, pero NO es disruptivo

`spec.selector` es **inmutable**. Un `helm upgrade` normal falla:

```
spec.selector: Invalid value: ... field is immutable
```

y **deja la release en `failed`**. Ahora bien, recrear el Deployment no implica downtime:

```bash
kubectl -n <ns> delete deploy <release>-adhoc-odoo --cascade=orphan
helm upgrade <release> <chart> -n <ns> --reuse-values --timeout 5m
```

El `--cascade=orphan` se lleva **solo** el objeto Deployment: el ReplicaSet y los pods siguen corriendo y sirviendo tráfico. Al recrearlo, el `pod-template-hash` es el mismo (el pod template no cambia), así que el Deployment nuevo **adopta el ReplicaSet existente** en lugar de crear uno nuevo.

## Validación

Ciclo completo en `test-biomega-10-08-1`:

| | |
| --- | --- |
| `helm upgrade` normal | falla con `field is immutable` (confirmado) |
| Pod tras el procedimiento | **el mismo**, `restartCount` 0, `startedAt` sin cambios |
| Health check | **HTTP 200** durante todo el procedimiento |
| Pods duplicados | ninguno — el RS fue adoptado |
| Endpoints del Service | sin interrupción |
| Selector nuevo | matchea **1** pod, donde el viejo matcheaba **2** |

## Tres condiciones a respetar

- **El pod template no puede cambiar en el mismo upgrade.** Si cambia, el hash cambia, no hay adopción y se hace rolling update normal — que con `replicaCount: 1` produce un blip. Conviene aislar este cambio en su propio upgrade.
- **No intentar el `helm upgrade` normal primero**: falla y deja la release en `failed`. El procedimiento funciona igual después, pero ensucia el historial.
- Entre los dos comandos hay unos segundos **sin Deployment**: si justo ahí se cae un pod, nadie lo recrea hasta el segundo comando. Encadenarlos.

Todo esto queda documentado en `doc/adhoc-odoo.md`, porque un selector inmutable no se cambia con un deploy normal y quien lo toque necesita saberlo.

## Test plan

- `helm lint`, `helm template`, chequeo de selectores y pre-commit en verde.
- Procedimiento validado de punta a punta en base de test (tabla de arriba).