### PR TITLE
fix: permitir los jobs del pipeline SaaS en la allowlist del Postgres (incidente)

### DIFF
--- a/charts/adhoc-odoo/templates/cnpg/networkPolicy.yaml
+++ b/charts/adhoc-odoo/templates/cnpg/networkPolicy.yaml
@@ -7,6 +7,11 @@
 # solo el de Odoo. Las probes del kubelet no hacen falta listarlas: Kubernetes NetworkPolicy
 # no filtra el tráfico del nodo hacia el pod (validado además en GKE Dataplane V2).
 #
+# Al agregar o cambiar reglas acá, tener presente que lo que conecta a la base NO es solo
+# Odoo en régimen: los flujos EPISÓDICOS (crear, restaurar, actualizar) usan jobs propios y
+# son los que no se ven mirando una base ya andando. Validar contra una creación de base
+# completa, no contra pg_stat_activity de una base en régimen.
+#
 # Lo que esta allowlist NO cubre, si alguna vez aparece: poolers (pgBouncer / Pooler de
 # CNPG), standby o subscribers lógicos fuera del namespace, y tooling externo que conecte
 # por SQL (dumps, BI, CDC, migraciones ad-hoc desde otro pod). Hoy no existe ninguno en la
@@ -42,6 +47,19 @@ spec:
         - podSelector:
             matchLabels:
               adhoc.ar/app-name: "pg-hook"
+      ports:
+        - protocol: TCP
+          port: 5432
+    # Jobs del pipeline SaaS (fixdb, restore, ...). NO los crea este chart, así que no
+    # aparecen en el render: los crea el provider en el namespace de la base y todos llevan
+    # la clave adhoc.ar/odoo-job. Se matchea por Exists para cubrir los que se sumen.
+    # Sin esta regla la creación de una base queda colgada en "Waiting until the database
+    # server is listening..." y nunca termina.
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: adhoc.ar/odoo-job
+                operator: Exists
       ports:
         - protocol: TCP
           port: 5432


### PR DESCRIPTION
> [!WARNING]
> **Arregla un incidente activo introducido por #133.** Desde ese merge, las bases nuevas no terminan de crearse. Conviene mergear rápido: cada base que se cree mientras tanto nace bloqueada.

## Qué está pasando

El job `fixdb` del pipeline SaaS queda colgado:

```
Waiting until the database server is listening...
labels: adhoc.ar/odoo-job: fixdb     ← no está en la allowlist de #133
```

Y el efecto se amplifica: el `podAntiAffinity` de `fixdb` es **`required`**, con `topologyKey: kubernetes.io/hostname` y `namespaceSelector` sobre **todos** los namespaces. O sea, un solo `fixdb` por nodo en todo el cluster. Con ~21 colgados, **el nodepool de cell01 escaló de 9 a 20 nodos**.

Alcance al detectarlo: 26 namespaces con la policy en cell01 y 24 jobs activos sin completar. En cell02 solo la base donde se validó #133, sin jobs colgados.

## El fix

Los jobs del pipeline **no los crea este chart**, así que no aparecen en su render: los crea el provider dentro del namespace de la base. Todos llevan la clave `adhoc.ar/odoo-job` (`fixdb`, `restore`), así que la regla matchea por `Exists` para cubrir los que se sumen.

## Validación

Desplegando el chart en `test-texterfeed-10-08-4`:

| Origen | 5432 |
| --- | --- |
| `adhoc.ar/odoo-job=fixdb` | ✅ accepting connections |
| `adhoc.ar/odoo-job=restore` | ✅ accepting connections |
| `adhoc.ar/app-name=odoo` | ✅ accepting connections |
| `adhoc.ar/app-name=intruso` | 🚫 no response |

La policy sigue filtrando lo que debe.

## Por qué no se detectó en #133

La validación de aquel PR midió `pg_stat_activity` de bases **en régimen**, donde `fixdb` ya había terminado hacía rato, y revisó los jobs **del chart** — por eso apareció `wait-pg` y se corrigió. Los jobs del pipeline viven fuera del chart y solo corren durante la creación.

La review automatizada lo había marcado de forma genérica ("jobs que conecten por SQL quedarían cortados, confianza alta") y se descartó con esa medición incompleta.

Queda una advertencia en el comentario del manifiesto: **una allowlist de ingress al Postgres se valida contra una creación de base completa, no contra una base ya andando.** Los flujos episódicos —crear, restaurar, actualizar— son los que no se ven en régimen.

## Nota aparte

El `podAntiAffinity` `required` de `fixdb` merece revisión propia (está en el pipeline, no en este chart): convertirlo en `preferred` evitaría que N jobs concurrentes fuercen N nodos.